### PR TITLE
Added default configuration to fall back to when unspecified

### DIFF
--- a/humphrey-server/Cargo.toml
+++ b/humphrey-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "humphrey_server"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 license = "MIT"
 homepage = "https://github.com/w-henderson/Humphrey"
@@ -11,7 +11,7 @@ keywords = ["http", "server", "http-server"]
 categories = ["web-programming::http-server", "network-programming", "command-line-utilities"]
 
 [dependencies]
-humphrey = { version = "0.1.2", path = "../humphrey" }
+humphrey = { version = "^0.1", path = "../humphrey" }
 libloading = { version = "0.7", optional = true }
 
 [features]

--- a/humphrey-server/src/config/default.rs
+++ b/humphrey-server/src/config/default.rs
@@ -1,0 +1,58 @@
+use crate::config::{
+    BlacklistConfig, BlacklistMode, CacheConfig, Config, LoggingConfig, RouteConfig,
+};
+use crate::server::logger::LogLevel;
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            address: "0.0.0.0".into(),
+            port: 80,
+            threads: 32,
+            websocket_proxy: None,
+            routes: vec![Default::default()],
+            #[cfg(feature = "plugins")]
+            plugins: Vec::new(),
+            logging: Default::default(),
+            cache: Default::default(),
+            blacklist: Default::default(),
+        }
+    }
+}
+
+impl Default for RouteConfig {
+    fn default() -> Self {
+        Self::Serve {
+            matches: "/*".into(),
+            directory: '.'.into(),
+        }
+    }
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            level: LogLevel::Info,
+            console: true,
+            file: None,
+        }
+    }
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self {
+            size_limit: Default::default(),
+            time_limit: Default::default(),
+        }
+    }
+}
+
+impl Default for BlacklistConfig {
+    fn default() -> Self {
+        Self {
+            list: Default::default(),
+            mode: BlacklistMode::Block,
+        }
+    }
+}

--- a/humphrey-server/src/config/mod.rs
+++ b/humphrey-server/src/config/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::module_inception)]
 
 pub mod config;
+pub mod default;
 pub mod error;
 pub mod extended_hashmap;
 pub mod traceback;


### PR DESCRIPTION
When no configuration file is specified, Humphrey looks for `humphrey.conf` in the current working directory first, then falls back to the default configuration if it cannot be found.