### PR TITLE
Write full inline documentation

### DIFF
--- a/humphrey-auth/src/app.rs
+++ b/humphrey-auth/src/app.rs
@@ -1,3 +1,5 @@
+//! Provides the authentication-related extensions to the Humphrey app.
+
 use crate::database::AuthDatabase;
 use crate::AuthProvider;
 
@@ -29,6 +31,7 @@ pub trait AuthState<D>
 where
     D: AuthDatabase,
 {
+    /// Returns a `MutexGuard` to the `AuthProvider`.
     fn auth_provider(&self) -> MutexGuard<AuthProvider<D>>;
 }
 

--- a/humphrey-auth/src/config.rs
+++ b/humphrey-auth/src/config.rs
@@ -1,3 +1,5 @@
+//! Contains configuration functionality for the authentication service.
+
 /// Represents the configuration of the authentication provider.
 #[derive(Clone)]
 pub struct AuthConfig {

--- a/humphrey-auth/src/database.rs
+++ b/humphrey-auth/src/database.rs
@@ -1,3 +1,6 @@
+//! Contains database traits for connecting the authentication service with a database of
+//!   your choosing. These are automatically implemented for `Vec<User>` as an example.
+
 use crate::error::AuthError;
 use crate::session::Session;
 use crate::user::User;

--- a/humphrey-auth/src/error.rs
+++ b/humphrey-auth/src/error.rs
@@ -1,3 +1,5 @@
+//! Provides error handling capabilities to the crate.
+
 use std::error::Error;
 use std::fmt::Display;
 

--- a/humphrey-auth/src/lib.rs
+++ b/humphrey-auth/src/lib.rs
@@ -24,6 +24,8 @@
 //! ## Example
 //! A basic example of username/password authentication can be found [here](https://github.com/w-henderson/Humphrey/tree/master/examples/auth).
 
+#![warn(missing_docs)]
+
 pub mod app;
 pub mod config;
 pub mod database;

--- a/humphrey-auth/src/session.rs
+++ b/humphrey-auth/src/session.rs
@@ -1,3 +1,5 @@
+//! Provides functionality for handling sessions and tokens.
+
 use std::time::UNIX_EPOCH;
 
 use rand_core::{OsRng, RngCore};
@@ -5,7 +7,9 @@ use rand_core::{OsRng, RngCore};
 /// Represents a session, containing a token and an expiration time.
 #[derive(Default, Clone, PartialEq, Eq)]
 pub struct Session {
+    /// The token string for this session.
     pub token: String,
+    /// The UNIX timestamp at which this session will expire.
     pub expiry: u64,
 }
 

--- a/humphrey-auth/src/user.rs
+++ b/humphrey-auth/src/user.rs
@@ -1,3 +1,5 @@
+//! Provides a user model for the authentication service.
+
 use crate::error::AuthError;
 use crate::session::Session;
 

--- a/humphrey-server/src/config/config.rs
+++ b/humphrey-server/src/config/config.rs
@@ -1,3 +1,5 @@
+//! Provides the core configuration functionality.
+
 use crate::config::extended_hashmap::ExtendedMap;
 use crate::config::tree::{parse_conf, ConfigNode};
 use crate::logger::LogLevel;
@@ -40,6 +42,7 @@ pub struct Config {
     pub blacklist: BlacklistConfig,
 }
 
+/// Represents the configuration for a specific host.
 #[derive(Debug, Default, PartialEq)]
 pub struct HostConfig {
     /// Wildcard string specifying what hosts to match, e.g. `*.example.com`
@@ -51,9 +54,13 @@ pub struct HostConfig {
 /// Represents the type of a route.
 #[derive(Debug, PartialEq)]
 pub enum RouteType {
+    /// Serve a single file.
     File,
+    /// Serve a directory of files.
     Directory,
+    /// Proxy requests to this route to another server.
     Proxy,
+    /// Redirect clients to another server.
     Redirect,
 }
 

--- a/humphrey-server/src/config/config.rs
+++ b/humphrey-server/src/config/config.rs
@@ -112,8 +112,11 @@ pub struct BlacklistConfig {
 #[cfg(feature = "tls")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TlsConfig {
+    /// The TLS certificate file path.
     pub cert_file: String,
+    /// The TLS key file path.
     pub key_file: String,
+    /// Whether to force clients to use HTTPS.
     pub force: bool,
 }
 
@@ -121,8 +124,11 @@ pub struct TlsConfig {
 #[cfg(feature = "plugins")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PluginConfig {
+    /// The name of the plugin.
     pub name: String,
+    /// The path to the shared library file.
     pub library: String,
+    /// The configuration for the plugin.
     pub config: HashMap<String, String>,
 }
 

--- a/humphrey-server/src/config/default.rs
+++ b/humphrey-server/src/config/default.rs
@@ -1,3 +1,5 @@
+//! Provides default values for the configuration.
+
 use crate::config::{
     BlacklistConfig, BlacklistMode, Config, LoggingConfig, RouteConfig, RouteType,
 };

--- a/humphrey-server/src/config/error.rs
+++ b/humphrey-server/src/config/error.rs
@@ -1,3 +1,5 @@
+//! Provides error handling functionality for the configuration parser.
+
 use std::error::Error;
 use std::fmt::Display;
 

--- a/humphrey-server/src/config/extended_hashmap.rs
+++ b/humphrey-server/src/config/extended_hashmap.rs
@@ -1,8 +1,12 @@
+//! Provides an extension of the `HashMap` type called `ExtendedMap`.
+
 use crate::config::tree::ConfigNode;
 
 use std::collections::HashMap;
 use std::str::FromStr;
 
+/// An extension of the standard HashMap that provides some syntactic sugar for working with
+///   optional and compulsory items, as well as errors.
 pub trait ExtendedMap<K, V> {
     /// Gets an item from the map by value.
     fn get_owned(&self, key: K) -> Option<V>;

--- a/humphrey-server/src/config/mod.rs
+++ b/humphrey-server/src/config/mod.rs
@@ -1,3 +1,5 @@
+//! Provides configuration functionality.
+
 #![allow(clippy::module_inception)]
 
 pub mod config;

--- a/humphrey-server/src/config/traceback.rs
+++ b/humphrey-server/src/config/traceback.rs
@@ -1,3 +1,5 @@
+//! Provides functionality for tracebacks.
+
 /// Wrapper for an iterator, counting the current index.
 /// Basically allows for the same thing as `enumerate` but not just in one statement.
 pub struct TracebackIterator<T>

--- a/humphrey-server/src/config/tree.rs
+++ b/humphrey-server/src/config/tree.rs
@@ -1,3 +1,5 @@
+//! Provides functionality for working with the configuration syntax tree.
+
 use crate::config::error::ConfigError;
 use crate::config::traceback::TracebackIterator;
 use humphrey::krauss::wildcard_match;
@@ -10,15 +12,22 @@ use std::str::Lines;
 /// Represents a node in the configuration syntax tree.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum ConfigNode {
+    /// A node that contains a number.
     Number(String, String),
+    /// A node that contains a boolean.
     Boolean(String, String),
+    /// A node that contains a string.
     String(String, String),
+    /// A node that represents a section and contains a number of child nodes.
     Section(String, Vec<ConfigNode>),
+    /// A node that represents a host's configuration and contains a number of child nodes.
     Host(String, Vec<ConfigNode>),
+    /// A node that represents a route's configuration and contains a number of child nodes.
     Route(String, Vec<ConfigNode>),
 }
 
 impl ConfigNode {
+    /// Flatten this node and all child nodes into a hashmap.
     pub fn flatten(&self, hashmap: &mut HashMap<String, Self>, level: &[&str]) {
         match self {
             ConfigNode::Section(k, v) => {
@@ -39,6 +48,7 @@ impl ConfigNode {
         }
     }
 
+    /// Get the hosts configured under this node.
     pub fn get_hosts(&self) -> Vec<(String, Self)> {
         let mut hosts: Vec<(String, Self)> = Vec::new();
 
@@ -53,6 +63,7 @@ impl ConfigNode {
         hosts
     }
 
+    /// Get the routes configured under this node.
     pub fn get_routes(&self) -> Vec<(String, HashMap<String, Self>)> {
         let mut routes: Vec<(String, HashMap<String, Self>)> = Vec::new();
 
@@ -85,6 +96,7 @@ impl ConfigNode {
         routes
     }
 
+    /// Get the plugins configured under this node.
     pub fn get_plugins(&self) -> Vec<(String, HashMap<String, Self>)> {
         let mut plugins: Vec<(String, HashMap<String, Self>)> = Vec::new();
         if let ConfigNode::Section(_, children) = self {
@@ -111,6 +123,7 @@ impl ConfigNode {
         plugins
     }
 
+    /// Get this node's value as a string, or `None` if this is not possible.
     pub fn get_string(&self) -> Option<String> {
         match self {
             ConfigNode::String(_, s) => Some(s.clone()),

--- a/humphrey-server/src/lib.rs
+++ b/humphrey-server/src/lib.rs
@@ -1,3 +1,8 @@
+//! # Humphrey Server
+//! Humphrey is a very fast, robust and flexible HTTP/1.1 web server, with support for static and dynamic content through its plugin system. It has no dependencies when only using default features, and is easily extensible with a configuration file and dynamically-loaded plugins.
+//!
+//! Read more [here](https://github.com/w-henderson/Humphrey/blob/master/humphrey-server/README.md).
+
 #![warn(missing_docs)]
 
 pub mod config;

--- a/humphrey-server/src/lib.rs
+++ b/humphrey-server/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(missing_docs)]
+
 pub mod config;
 pub mod server;
 pub use server::*;

--- a/humphrey-server/src/plugins/manager.rs
+++ b/humphrey-server/src/plugins/manager.rs
@@ -1,6 +1,6 @@
 //! Plugin management code.
 //!
-//! https://michael-f-bryan.github.io/rust-ffi-guide/dynamic_loading.html
+//! <https://michael-f-bryan.github.io/rust-ffi-guide/dynamic_loading.html>
 
 use crate::config::RouteConfig;
 use crate::plugins::plugin::{Plugin, PluginLoadResult};

--- a/humphrey-server/src/plugins/mod.rs
+++ b/humphrey-server/src/plugins/mod.rs
@@ -1,2 +1,4 @@
+//! Provides functionality for dynamically-loaded plugins.
+
 pub mod manager;
 pub mod plugin;

--- a/humphrey-server/src/plugins/plugin.rs
+++ b/humphrey-server/src/plugins/plugin.rs
@@ -1,6 +1,6 @@
 //! Types used when creating a plugin.
 //!
-//! https://michael-f-bryan.github.io/rust-ffi-guide/dynamic_loading.html
+//! <https://michael-f-bryan.github.io/rust-ffi-guide/dynamic_loading.html>
 
 #![allow(unused_variables)]
 #![allow(dead_code)]

--- a/humphrey-server/src/server/cache.rs
+++ b/humphrey-server/src/server/cache.rs
@@ -1,3 +1,5 @@
+//! Provides caching functionality.
+
 use crate::config::Config;
 
 use humphrey::http::mime::MimeType;
@@ -6,6 +8,7 @@ use std::{collections::VecDeque, time::SystemTime};
 /// Represents the server's cache.
 #[derive(Default)]
 pub struct Cache {
+    /// The cache's maximum size.
     pub cache_limit: usize,
     cache_time_limit: u64,
     cache_size: usize,
@@ -14,10 +17,15 @@ pub struct Cache {
 
 /// Represents a cached item.
 pub struct CachedItem {
+    /// The route that this item was served at.
     pub route: String,
+    /// The host that this item was served at.
     pub host: usize,
+    /// The MIME type of the item.
     pub mime_type: MimeType,
+    /// The time at which the item was cached.
     pub cache_time: u64,
+    /// The item's data.
     pub data: Vec<u8>,
 }
 

--- a/humphrey-server/src/server/logger.rs
+++ b/humphrey-server/src/server/logger.rs
@@ -1,3 +1,5 @@
+//! Provides logging functionality.
+
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::str::FromStr;

--- a/humphrey-server/src/server/mod.rs
+++ b/humphrey-server/src/server/mod.rs
@@ -1,3 +1,5 @@
+//! Provides the server functionality.
+
 #![allow(clippy::module_inception)]
 
 pub mod cache;

--- a/humphrey-server/src/server/proxy.rs
+++ b/humphrey-server/src/server/proxy.rs
@@ -1,3 +1,5 @@
+//! Provides HTTP proxy functionality.
+
 use crate::config::LoadBalancerMode;
 use crate::rand::{Choose, Lcg};
 use crate::server::server::AppState;
@@ -13,9 +15,13 @@ use std::time::Duration;
 /// Represents a load balancer.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LoadBalancer {
+    /// The targets of the load balancer.
     pub targets: Vec<String>,
+    /// The algorithm used to choose a target.
     pub mode: LoadBalancerMode,
+    /// The current target.
     pub index: usize,
+    /// The random number generator used by the load balancer.
     pub lcg: Lcg,
 }
 
@@ -37,6 +43,7 @@ impl LoadBalancer {
     }
 }
 
+/// Handles proxy requests.
 pub fn proxy_handler(
     request: Request,
     state: Arc<AppState>,
@@ -101,10 +108,12 @@ pub struct EqMutex<T> {
 }
 
 impl<T> EqMutex<T> {
+    /// Locks the mutex.
     pub fn lock(&self) -> Result<MutexGuard<T>, PoisonError<MutexGuard<T>>> {
         self.mutex.lock()
     }
 
+    /// Creates a new mutex.
     pub fn new(data: T) -> Self {
         Self {
             mutex: Mutex::new(data),

--- a/humphrey-server/src/server/rand.rs
+++ b/humphrey-server/src/server/rand.rs
@@ -1,3 +1,5 @@
+//! Provides a simple LCG implementation for generating random numbers.
+
 use std::time::SystemTime;
 
 /// Represents a linear congruential generator, used to generate random `u32` numbers.
@@ -11,6 +13,7 @@ pub struct Lcg {
 
 /// Allows random sampling on an object.
 pub trait Choose {
+    /// The type of the object.
     type Item;
 
     /// Selects a random item from the collection.

--- a/humphrey-server/src/server/server.rs
+++ b/humphrey-server/src/server/server.rs
@@ -1,3 +1,5 @@
+//! Provides the core server functionality and manages the underlying Humphrey app.
+
 use humphrey::http::{Request, Response};
 use humphrey::stream::Stream;
 use humphrey::{App, SubApp};
@@ -23,9 +25,13 @@ use std::sync::{Arc, RwLock};
 /// Represents the application state.
 /// Includes the target directory, cache state, and the logger.
 pub struct AppState {
+    /// The app's configuration.
     pub config: Config,
+    /// The app's cache.
     pub cache: RwLock<Cache>,
+    /// The app's logger.
     pub logger: Logger,
+    /// The app's plugin manager.
     #[cfg(feature = "plugins")]
     pub plugin_manager: RwLock<PluginManager>,
 }

--- a/humphrey-server/src/server/static.rs
+++ b/humphrey-server/src/server/static.rs
@@ -1,3 +1,5 @@
+//! Provides functionality for serving static content.
+
 use crate::server::server::AppState;
 
 use humphrey::http::headers::ResponseHeader;
@@ -161,6 +163,7 @@ fn cache_check(request: &Request, state: Arc<AppState>, host: usize) -> Option<R
     None
 }
 
+/// Generates a 404 response.
 pub fn not_found() -> Response {
     Response::empty(StatusCode::NotFound)
         .with_header(ResponseHeader::ContentType, "text/html".into())

--- a/humphrey-ws/src/error.rs
+++ b/humphrey-ws/src/error.rs
@@ -1,3 +1,5 @@
+//! Provides error handling for the WebSocket crate.
+
 use std::error::Error;
 use std::fmt::Display;
 

--- a/humphrey-ws/src/frame.rs
+++ b/humphrey-ws/src/frame.rs
@@ -1,3 +1,5 @@
+//! Provides an implementation of WebSocket frames as specified in [RFC 6455 Section 5](https://datatracker.ietf.org/doc/html/rfc6455#section-5).
+
 use crate::error::WebsocketError;
 use crate::util::restion::Restion;
 

--- a/humphrey-ws/src/handler.rs
+++ b/humphrey-ws/src/handler.rs
@@ -1,3 +1,5 @@
+//! Provides a Humphrey-compatible WebSocket handler for performing the handshake.
+
 use crate::error::WebsocketError;
 use crate::stream::WebsocketStream;
 use crate::util::base64::Base64Encode;

--- a/humphrey-ws/src/lib.rs
+++ b/humphrey-ws/src/lib.rs
@@ -59,6 +59,8 @@
 //! ## Further Examples
 //! - [Echo Server](https://github.com/w-henderson/Humphrey/tree/master/examples/websocket): echoes received messages back to the client with an incrementing number at the end
 
+#![warn(missing_docs)]
+
 const MAGIC_STRING: &str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 pub mod error;

--- a/humphrey-ws/src/message.rs
+++ b/humphrey-ws/src/message.rs
@@ -1,3 +1,5 @@
+//! Provides an abstraction over WebSocket frames called `Message`.
+
 use crate::error::WebsocketError;
 use crate::frame::{Frame, Opcode};
 use crate::restion::Restion;
@@ -87,6 +89,9 @@ impl Message {
         })
     }
 
+    /// Attemps to read a message from the given stream without blocking.
+    ///
+    /// Silently responds to pings with pongs, as specified in [RFC 6455 Section 5.5.2](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.2).
     pub fn from_stream_nonblocking(mut stream: &mut TcpStream) -> Restion<Self, WebsocketError> {
         let mut frames: Vec<Frame> = Vec::new();
         let mut is_first_frame = true;

--- a/humphrey-ws/src/stream.rs
+++ b/humphrey-ws/src/stream.rs
@@ -1,3 +1,5 @@
+//! Provides functionality for working with a WebSocket stream.
+
 use crate::error::WebsocketError;
 use crate::frame::{Frame, Opcode};
 use crate::message::Message;
@@ -54,6 +56,7 @@ where
 }
 
 impl WebsocketStream<TcpStream> {
+    /// Attemps to receive a message from the stream without blocking.
     pub fn recv_nonblocking(&mut self) -> Restion<Message, WebsocketError> {
         let message = Message::from_stream_nonblocking(&mut self.stream);
 

--- a/humphrey-ws/src/util/mod.rs
+++ b/humphrey-ws/src/util/mod.rs
@@ -1,3 +1,5 @@
+//! Provides necessary utilities for the WebSocket crate.
+
 pub mod base64;
 pub mod restion;
 pub mod sha1;

--- a/humphrey-ws/src/util/restion.rs
+++ b/humphrey-ws/src/util/restion.rs
@@ -1,3 +1,5 @@
+//! Provides the `Restion` type, a combination of `Result` and `Option`.
+
 use std::fmt::Debug;
 
 /// A combination of `Result` and `Option`, used to represent the result of non-blocking operations.

--- a/humphrey/src/app.rs
+++ b/humphrey/src/app.rs
@@ -1,3 +1,5 @@
+//! Provides the core Humphrey app functionality.
+
 #![allow(clippy::new_without_default)]
 
 use crate::http::headers::RequestHeader;

--- a/humphrey/src/handlers.rs
+++ b/humphrey/src/handlers.rs
@@ -1,3 +1,5 @@
+//! Provides a number of useful handlers for Humphrey apps.
+
 use crate::app::error_handler;
 use crate::http::headers::ResponseHeader;
 use crate::http::{Request, Response, StatusCode};

--- a/humphrey/src/http/address.rs
+++ b/humphrey/src/http/address.rs
@@ -1,3 +1,5 @@
+//! Provides functionality for parsing and representing network addresses.
+
 use crate::http::headers::{RequestHeader, RequestHeaderMap};
 
 use std::fmt::Display;

--- a/humphrey/src/http/date.rs
+++ b/humphrey/src/http/date.rs
@@ -1,3 +1,5 @@
+//! Provides functionality for handling HTTP date timestamps.
+
 use std::time::SystemTime;
 
 const DAYS: [&str; 7] = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -17,17 +19,26 @@ const MARCH_01_2000: i64 = 951868800;
 
 /// Represents a date and time.
 pub struct DateTime {
+    /// The UNIX timestamp of the date.
     pub timestamp: i64,
+    /// The year of the date.
     pub year: u16,
+    /// The month of the date.
     pub month: u8,
+    /// The day of the month of the date.
     pub day: u8,
+    /// The weekday of the date.
     pub weekday: u8,
+    /// The hour of the date.
     pub hour: u8,
+    /// The minute of the date.
     pub minute: u8,
+    /// The second of the date.
     pub second: u8,
 }
 
 impl DateTime {
+    /// Creates a new `DateTime` from the current time.
     pub fn now() -> Self {
         let timestamp = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -37,6 +48,7 @@ impl DateTime {
         Self::from(timestamp)
     }
 
+    /// Returns the UNIX timestamp of the date.
     pub fn get_timestamp(&self) -> i64 {
         self.timestamp
     }

--- a/humphrey/src/http/headers.rs
+++ b/humphrey/src/http/headers.rs
@@ -1,3 +1,5 @@
+//! Provides functionality for handling HTTP headers.
+
 use std::collections::BTreeMap;
 
 /// Alias for a map of request headers and their values.
@@ -9,33 +11,58 @@ pub type ResponseHeaderMap = BTreeMap<ResponseHeader, String>;
 /// Represents a header received in a request.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum RequestHeader {
+    /// Informs the server about the types of data that can be sent back.
     Accept,
+    /// Informs the server about the accepted character encodings.
     AcceptCharset,
+    /// Indicates the content encoding(s) understood by the client, usually compression algorithms.
     AcceptEncoding,
+    /// Informs the server about the client's language(s).
     AcceptLanguage,
+    /// Indicates the method that will be used for the actual request when performing an OPTIONS request.
     AccessControlRequestMethod,
+    /// Provides credentials for HTTP authentication.
     Authorization,
+    /// Indicates how the cache should behave.
     CacheControl,
+    /// Indicates what should happen to the connection after the request is served.
     Connection,
+    /// Lists any encodings used on the payload.
     ContentEncoding,
+    /// Indicates the length of the payload body.
     ContentLength,
+    /// Indicates the MIME type of the payload body.
     ContentType,
+    /// Shares any applicable HTTP cookies with the server.
     Cookie,
+    /// Indicates the date and time at which the request was sent.
     Date,
+    /// Indicates any expectations that must be met by the server in order to properly serve the request.
     Expect,
+    /// May contain reverse proxy information, generally not used in favour of the `X-Forwarded-For` header.
     Forwarded,
+    /// Indicates the email address of the client, often used by crawlers.
     From,
+    /// Specifies the host to which the request is being sent, e.g. "www.example.com".
     Host,
+    /// Indicates the origin that caused the request.
     Origin,
+    /// Contains backwards-compatible caching information.
     Pragma,
+    /// Indicates the absolute or partial address of the page making the request.
     Referer,
+    /// Indicates that the connection is to be upgraded to a different protocol, e.g. WebSocket.
     Upgrade,
+    /// Informs the server of basic browser and device information.
     UserAgent,
+    /// Contains the addresses of proxies through which the request has been forwarded.
     Via,
+    /// Contains information about possible problems with the request.
     Warning,
 
     /// Custom header with a lowercase name
     Custom {
+        /// The name of the header.
         name: String,
     },
 }
@@ -43,31 +70,58 @@ pub enum RequestHeader {
 /// Represents a header sent in a response.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ResponseHeader {
+    /// Indicates whether the response can be shared with other origins.
     AccessControlAllowOrigin,
+    /// Contains the time in seconds that the object has been cached.
     Age,
+    /// The set of methods supported by the resource.
     Allow,
+    /// Indicates how the cache should behave.
     CacheControl,
+    /// Indicates what should happen to the connection after the request is served.
     Connection,
+    /// Indicates whether the response is to be displayed as a webpage or downloaded directly.
     ContentDisposition,
+    /// Lists any encodings used on the payload.
     ContentEncoding,
+    /// Informs the client of the language of the payload body.
     ContentLanguage,
+    /// Indicates the length of the payload body.
     ContentLength,
+    /// Indicates an alternative location for the returned data.
     ContentLocation,
+    /// Indicates the MIME type of the payload body.
     ContentType,
+    /// Indicates the date and time at which the response was created.
     Date,
+    /// Identifies a specific version of a resource.
     ETag,
+    /// Contains the date and time at which the response is considered expired.
     Expires,
+    /// Indicates the date and time at which the response was last modified.
     LastModified,
+    /// Provides a means for serialising links in the headers, equivalent to the HTML `<link>` element.
     Link,
+    /// Indicates the location at which the resource can be found, used for redirects.
     Location,
+    /// Contains backwards-compatible caching information.
     Pragma,
+    /// Contains information about the server which served the request.
     Server,
+    /// Indicates that the client should set the specified cookies.
     SetCookie,
+    /// Indicates that the connection is to be upgraded to a different protocol, e.g. WebSocket.
     Upgrade,
+    /// Contains the addresses of proxies through which the response has been forwarded.
     Via,
+    /// Contains information about possible problems with the response.
     Warning,
 
-    Custom { name: String },
+    /// Custom header with a lowercase name
+    Custom {
+        /// The name of the header.
+        name: String,
+    },
 }
 
 impl PartialOrd for ResponseHeader {

--- a/humphrey/src/http/method.rs
+++ b/humphrey/src/http/method.rs
@@ -1,3 +1,5 @@
+//! Provides functionality for handling HTTP methods.
+
 use super::request::RequestError;
 
 use std::fmt::Display;
@@ -5,9 +7,13 @@ use std::fmt::Display;
 /// Represents an HTTP method.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Method {
+    /// The `GET` method.
     Get,
+    /// The `POST` method.
     Post,
+    /// The `PUT` method.
     Put,
+    /// The `DELETE` method.
     Delete,
 }
 

--- a/humphrey/src/http/mime.rs
+++ b/humphrey/src/http/mime.rs
@@ -1,27 +1,51 @@
+//! Provides functionality for handling MIME types.
+
 /// Represents a MIME type as used in the `Content-Type` header.
 #[derive(Clone, Copy)]
 pub enum MimeType {
+    /// The `text/css` MIME type.
     TextCss,
+    /// The `text/html` MIME type.
     TextHtml,
+    /// The `text/javascript` MIME type.
     TextJavaScript,
+    /// The `text/plain` MIME type.
     TextPlain,
+    /// The `image/bmp` MIME type.
     ImageBmp,
+    /// The `image/gif` MIME type.
     ImageGif,
+    /// The `image/jpeg` MIME type.
     ImageJpeg,
+    /// The `image/png` MIME type.
     ImagePng,
+    /// The `image/webp` MIME type.
     ImageWebp,
+    /// The `image/svg+xml` MIME type.
     ImageSvg,
+    /// The `image/vnd.microsoft.icon` MIME type.
     ImageIcon,
+    /// The `application/octet-stream` MIME type.
     ApplicationOctetStream,
+    /// The `application/json` MIME type.
     ApplicationJson,
+    /// The `application/pdf` MIME type.
     ApplicationPdf,
+    /// The `application/zip` MIME type.
     ApplicationZip,
+    /// The `video/mp4` MIME type.
     VideoMp4,
+    /// The `video/ogg` MIME type.
     VideoOgg,
+    /// The `video/webm` MIME type.
     VideoWebm,
+    /// The `font/ttf` MIME type.
     FontTtf,
+    /// The `font/otf` MIME type.
     FontOtf,
+    /// The `font/woff` MIME type.
     FontWoff,
+    /// The `font/woff2` MIME type.
     FontWoff2,
 }
 

--- a/humphrey/src/http/mod.rs
+++ b/humphrey/src/http/mod.rs
@@ -1,3 +1,5 @@
+//! Contains the Humphrey HTTP implementation.
+
 pub mod address;
 pub mod date;
 pub mod headers;

--- a/humphrey/src/http/proxy.rs
+++ b/humphrey/src/http/proxy.rs
@@ -1,3 +1,5 @@
+//! Provides functionality for HTTP proxying.
+
 use crate::http::headers::RequestHeader;
 use crate::http::response::ResponseError;
 use crate::http::{Request, Response, StatusCode};

--- a/humphrey/src/http/request.rs
+++ b/humphrey/src/http/request.rs
@@ -1,3 +1,5 @@
+//! Provides functionality for handling HTTP requests.
+
 use crate::http::address::Address;
 use crate::http::headers::{RequestHeader, RequestHeaderMap};
 use crate::http::method::Method;

--- a/humphrey/src/http/response.rs
+++ b/humphrey/src/http/response.rs
@@ -1,3 +1,5 @@
+//! Provides functionality for handling HTTP responses.
+
 use crate::http::date::DateTime;
 use crate::http::headers::{RequestHeader, ResponseHeader, ResponseHeaderMap};
 use crate::http::request::Request;

--- a/humphrey/src/http/status.rs
+++ b/humphrey/src/http/status.rs
@@ -1,3 +1,5 @@
+//! Provides functionality for handling HTTP status codes.
+
 use std::convert::TryFrom;
 
 /// Represents an HTTP status code.
@@ -16,47 +18,87 @@ use std::convert::TryFrom;
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum StatusCode {
+    /// `100 Continue`: Continue with request.
     Continue,
+    /// `101 Switching Protocols`: Protocol upgrade.
     SwitchingProtocols,
+    /// `200 OK`: Request succeeded.
     OK,
+    /// `201 Created`: Resource created.
     Created,
+    /// `202 Accepted`: Request received, but not yet acted upon.
     Accepted,
+    /// `203 Non-Authoritative Information`: Request processed, but response is from another source.
     NonAuthoritative,
+    /// `204 No Content`: There is no content to send for this request.
     NoContent,
+    /// `205 Reset Content`: Indicates that the document which sent this request should be reset.
     ResetContent,
+    /// `206 Partial Content`: This response only contains part of a resource.
     PartialContent,
+    /// `300 Multiple Choice`: The request has multiple possible responses.
     MultipleChoices,
+    /// `301 Moved Permanently`: The resource has moved permanently to a new location.
     MovedPermanently,
+    /// `302 Found`: The resource has moved temporarily to a new location.
     Found,
+    /// `303 See Other`: The resource can be found under a different URI.
     SeeOther,
+    /// `304 Not Modified`: The resource has not been modified since the last request.
     NotModified,
+    /// `305 Use Proxy`: The requested resource must be accessed through a proxy.
     UseProxy,
+    /// `307 Temporary Redirect`: The resource has moved temporarily to a new location.
     TemporaryRedirect,
+    /// `400 Bad Request`: The request could not be understood by the server.
     BadRequest,
+    /// `401 Unauthorized`: The request requires user authentication.
     Unauthorized,
+    /// `403 Forbidden`: The client is not allowed to access this content.
     Forbidden,
+    /// `404 Not Found`: The server can not find the requested resource.
     NotFound,
+    /// `405 Method Not Allowed`: The method specified in the request is not allowed for the resource.
     MethodNotAllowed,
+    /// `406 Not Acceptable`: No content that meets the criteria is available.
     NotAcceptable,
+    /// `407 Proxy Authentication Required`: The client must first authenticate itself with a proxy.
     ProxyAuthenticationRequired,
+    /// `408 Request Timeout`: The server timed out waiting for the request.
     RequestTimeout,
+    /// `409 Conflict`: The request could not be completed because of a conflict with the server's current state.
     Conflict,
+    /// `410 Gone`: The requested resource is no longer available.
     Gone,
+    /// `411 Length Required`: The request did not specify the length of its content.
     LengthRequired,
+    /// `412 Precondition Failed`: The server does not meet one of the client's preconditions.
     PreconditionFailed,
+    /// `413 Payload Too Large`: The request is larger than the server is willing or able to process.
     RequestEntityTooLarge,
+    /// `414 URI Too Long`: The URI provided was too long for the server to process.
     RequestURITooLong,
+    /// `415 Unsupported Media Type`: The request entity has a media type which the server or resource does not support.
     UnsupportedMediaType,
+    /// `416 Requested Range Not Satisfiable`: The range specified in the `Range` header cannot be fulfilled.
     RequestedRangeNotSatisfiable,
+    /// `417 Expectation Failed`: The expectation given in the `Expect` header could not be met by the server.
     ExpectationFailed,
+    /// `500 Internal Server Error`: The server encountered an unexpected error which prevented it from fulfilling the request.
     InternalError,
+    /// `501 Not Implemented`: The server does not support the functionality required to fulfill the request.
     NotImplemented,
+    /// `502 Bad Gateway`: The server, while acting as a gateway or proxy, received an invalid response from the upstream server.
     BadGateway,
+    /// `503 Service Unavailable`: The server is temporarily unable to handle the request.
     ServiceUnavailable,
+    /// `504 Gateway Timeout`: The server, while acting as a gateway or proxy, did not receive a timely response from the upstream server.
     GatewayTimeout,
+    /// `505 HTTP Version Not Supported`: The server does not support the HTTP protocol version used in the request.
     VersionNotSupported,
 }
 
+/// Represents an error with the status code.
 #[derive(PartialEq, Eq)]
 pub struct StatusCodeError;
 

--- a/humphrey/src/krauss.rs
+++ b/humphrey/src/krauss.rs
@@ -1,3 +1,5 @@
+//! Provides an implementation of [Krauss' wildcard-matching algorithm](https://www.drdobbs.com/architecture-and-design/matching-wildcards-an-algorithm/210200888).
+
 use std::iter::Peekable;
 use std::str::Chars;
 

--- a/humphrey/src/lib.rs
+++ b/humphrey/src/lib.rs
@@ -41,6 +41,8 @@
 //! - [Wildcard Example](https://github.com/w-henderson/Humphrey/tree/master/examples/wildcard): demonstrates a wildcard route
 //! - [Static Content Example](https://github.com/w-henderson/Humphrey/tree/master/examples/static-content): demonstrates the built-in static content handlers
 
+#![warn(missing_docs)]
+
 pub mod app;
 pub mod handlers;
 pub mod http;

--- a/humphrey/src/route.rs
+++ b/humphrey/src/route.rs
@@ -1,3 +1,5 @@
+//! Provides functionality for handling app routes.
+
 use crate::app::{
     PathAwareRequestHandler, RequestHandler, StatelessRequestHandler, WebsocketHandler,
 };
@@ -8,20 +10,27 @@ use std::path::PathBuf;
 
 /// Represents a sub-app to run for a specific host.
 pub struct SubApp<State> {
+    /// The host to process requests for.
     pub host: String,
+    /// The routes to process requests for and their handlers.
     pub routes: Vec<RouteHandler<State>>,
+    /// The routes to process WebSocket requests for and their handlers.
     pub websocket_routes: Vec<WebsocketRouteHandler<State>>,
 }
 
 /// Encapsulates a route and its handler.
 pub struct RouteHandler<State> {
+    /// The route that this handler will match.
     pub route: String,
+    /// The handler to run when the route is matched.
     pub handler: Box<dyn RequestHandler<State>>,
 }
 
 /// Encapsulates a route and its WebSocket handler.
 pub struct WebsocketRouteHandler<State> {
+    /// The route that this handler will match.
     pub route: String,
+    /// The handler to run when the route is matched.
     pub handler: Box<dyn WebsocketHandler<State>>,
 }
 
@@ -101,6 +110,7 @@ impl<State> SubApp<State> {
 
 /// An object that can represent a route, currently only `String`.
 pub trait Route {
+    /// Returns true if the given route matches the path.
     fn route_matches(&self, route: &str) -> bool;
 }
 
@@ -114,7 +124,9 @@ impl Route for String {
 
 /// A located file or directory path.
 pub enum LocatedPath {
+    /// A directory was located.
     Directory,
+    /// A file was located at the given path.
     File(PathBuf),
 }
 

--- a/humphrey/src/thread/mod.rs
+++ b/humphrey/src/thread/mod.rs
@@ -1,1 +1,3 @@
+//! Provides a basic thread pool implementation.
+
 pub mod pool;

--- a/humphrey/src/thread/pool.rs
+++ b/humphrey/src/thread/pool.rs
@@ -1,3 +1,5 @@
+//! Provides thread pool functionality.
+
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread::{spawn, JoinHandle};
@@ -17,7 +19,9 @@ pub struct Thread {
 
 /// Represents a message between threads.
 pub enum Message {
+    /// A task to be processed by a thread.
     Function(Task),
+    /// The thread should be shut down.
     Shutdown,
 }
 


### PR DESCRIPTION
The clippy lint `#![warn(missing_docs)]` has been added to every crate and all the issues have been fixed.