### PR TITLE
Implemented a connection timeout (fixes #66)

### DIFF
--- a/docs/src/server/configuration.md
+++ b/docs/src/server/configuration.md
@@ -9,6 +9,7 @@ server {
   address   "0.0.0.0"        # Address to host the server on
   port      443              # Port to host the server on
   threads   32               # Number of threads to use for the server
+  timeout   5                # Timeout for requests, highly recommended to avoid deadlocking the thread pool
 
   plugins { # Plugin configuration (only supported with the `plugins` feature)
     include "php.conf"       # Include PHP configuration (see next page)

--- a/humphrey-server/Cargo.toml
+++ b/humphrey-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "humphrey_server"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2018"
 license = "MIT"
 homepage = "https://github.com/w-henderson/Humphrey"
@@ -11,7 +11,7 @@ keywords = ["http", "server", "http-server"]
 categories = ["web-programming::http-server", "network-programming", "command-line-utilities"]
 
 [dependencies]
-humphrey = { version = "^0.4", path = "../humphrey" }
+humphrey = { version = "^0.4.4", path = "../humphrey" }
 libloading = { version = "0.7", optional = true }
 
 [features]

--- a/humphrey-server/src/config/config.rs
+++ b/humphrey-server/src/config/config.rs
@@ -12,6 +12,7 @@ use std::env::args;
 use std::fs::File;
 use std::io::Read;
 use std::net::IpAddr;
+use std::time::Duration;
 
 /// Represents the parsed and validated configuration.
 #[derive(Debug, PartialEq)]
@@ -40,6 +41,8 @@ pub struct Config {
     pub cache: CacheConfig,
     /// Blacklist configuration
     pub blacklist: BlacklistConfig,
+    /// The amount of time to wait between requests
+    pub connection_timeout: Option<Duration>,
 }
 
 /// Represents the configuration for a specific host.
@@ -179,6 +182,13 @@ impl Config {
         let threads: usize =
             hashmap.get_optional_parsed("server.threads", 32, "Invalid number of threads")?;
         let default_websocket_proxy = hashmap.get_owned("server.websocket");
+        let connection_timeout_seconds: u64 =
+            hashmap.get_optional_parsed("server.timeout", 0, "Invalid connection timeout")?;
+        let connection_timeout = if connection_timeout_seconds > 0 {
+            Some(Duration::from_secs(connection_timeout_seconds))
+        } else {
+            None
+        };
 
         // Get and validate the blacklist file and mode
         let blacklist = {
@@ -314,6 +324,7 @@ impl Config {
             logging,
             cache,
             blacklist,
+            connection_timeout,
         })
     }
 

--- a/humphrey-server/src/config/default.rs
+++ b/humphrey-server/src/config/default.rs
@@ -21,6 +21,7 @@ impl Default for Config {
             logging: Default::default(),
             cache: Default::default(),
             blacklist: Default::default(),
+            connection_timeout: Default::default(),
         }
     }
 }

--- a/humphrey-server/src/server/server.rs
+++ b/humphrey-server/src/server/server.rs
@@ -8,7 +8,6 @@ use humphrey::{App, SubApp};
 use crate::plugins::manager::PluginManager;
 #[cfg(feature = "plugins")]
 use crate::plugins::plugin::PluginLoadResult;
-use std::error::Error;
 #[cfg(feature = "plugins")]
 use std::process::exit;
 
@@ -18,6 +17,7 @@ use crate::logger::Logger;
 use crate::proxy::proxy_handler;
 use crate::r#static::{directory_handler, file_handler, redirect_handler};
 
+use std::error::Error;
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::sync::{Arc, RwLock};
@@ -52,8 +52,11 @@ impl From<Config> for AppState {
 
 /// Main function for the static server.
 pub fn main(config: Config) {
+    let connection_timeout = config.connection_timeout;
+
     let mut app: App<AppState> = App::new_with_config(config.threads, AppState::from(config))
-        .with_connection_condition(verify_connection);
+        .with_connection_condition(verify_connection)
+        .with_connection_timeout(connection_timeout);
 
     let state = app.get_state();
 

--- a/humphrey-server/src/tests/config.rs
+++ b/humphrey-server/src/tests/config.rs
@@ -14,6 +14,7 @@ use humphrey_server::proxy::{EqMutex, LoadBalancer};
 use humphrey_server::rand::Lcg;
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 #[test]
 fn test_parse_config() {
@@ -80,6 +81,7 @@ fn test_parse_config() {
             list: Vec::new(),
             mode: BlacklistMode::Block,
         },
+        connection_timeout: Some(Duration::from_secs(5)),
     };
 
     assert_eq!(conf, expected_conf);
@@ -144,6 +146,7 @@ fn test_host_config() {
             list: Vec::new(),
             mode: BlacklistMode::Block,
         },
+        connection_timeout: None,
     };
 
     assert_eq!(conf, expected_conf);
@@ -196,6 +199,7 @@ fn comma_separated_routes() {
             list: Vec::new(),
             mode: BlacklistMode::Block,
         },
+        connection_timeout: None,
     };
 
     assert_eq!(conf, expected_conf);

--- a/humphrey-server/src/tests/include.rs
+++ b/humphrey-server/src/tests/include.rs
@@ -52,6 +52,7 @@ fn include_route() {
             list: Vec::new(),
             mode: BlacklistMode::Block,
         },
+        connection_timeout: None,
     });
 
     assert_eq!(config, expected_conf);
@@ -104,6 +105,7 @@ fn nested_include() {
             list: Vec::new(),
             mode: BlacklistMode::Block,
         },
+        connection_timeout: None,
     });
 
     assert_eq!(config, expected_conf);

--- a/humphrey-server/src/tests/testcases/valid.conf
+++ b/humphrey-server/src/tests/testcases/valid.conf
@@ -6,6 +6,7 @@ server {
     port       80
     threads    32
     websocket  "localhost:1234"
+    timeout    5
 
     plugins { # this is a comment on a section header
         php {

--- a/humphrey-server/src/tests/tree.rs
+++ b/humphrey-server/src/tests/tree.rs
@@ -14,6 +14,7 @@ fn test_build_tree() {
         ConfigNode::Number("port".into(), "80".into()),
         ConfigNode::Number("threads".into(), "32".into()),
         ConfigNode::String("websocket".into(), "localhost:1234".into()),
+        ConfigNode::Number("timeout".into(), "5".into()),
         ConfigNode::Section("plugins".into(), vec![
             ConfigNode::Section("php".into(), vec![
                 ConfigNode::String("library".into(), "plugins/php/target/release/php.dll".into()),
@@ -58,6 +59,7 @@ fn test_flatten_config() {
     expected_hashmap.insert("server.port".into(), ConfigNode::Number("port".into(), "80".into()));
     expected_hashmap.insert("server.threads".into(), ConfigNode::Number("threads".into(), "32".into()));
     expected_hashmap.insert("server.websocket".into(), ConfigNode::String("websocket".into(), "localhost:1234".into()));
+    expected_hashmap.insert("server.timeout".into(), ConfigNode::Number("timeout".into(), "5".into()));
     expected_hashmap.insert("server.blacklist.mode".into(), ConfigNode::String("mode".into(), "block".into()));
     expected_hashmap.insert("server.log.level".into(), ConfigNode::String("level".into(), "info".into()));
     expected_hashmap.insert("server.log.console".into(), ConfigNode::Boolean("console".into(), "true".into()));

--- a/humphrey/Cargo.toml
+++ b/humphrey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "humphrey"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2018"
 license = "MIT"
 homepage = "https://github.com/w-henderson/Humphrey"

--- a/humphrey/src/app.rs
+++ b/humphrey/src/app.rs
@@ -244,6 +244,7 @@ where
                 let cloned_default_subapp = default_subapp.clone();
                 let cloned_error_handler = error_handler.clone();
                 let cloned_handler = self.connection_handler;
+                let cloned_timeout = self.connection_timeout;
                 let cloned_config = self
                     .tls_config
                     .as_ref()
@@ -262,6 +263,7 @@ where
                         cloned_default_subapp,
                         cloned_error_handler,
                         cloned_state,
+                        cloned_timeout,
                     )
                 });
             }

--- a/humphrey/src/tests/mock_stream.rs
+++ b/humphrey/src/tests/mock_stream.rs
@@ -1,28 +1,31 @@
 #![allow(dead_code)]
 
+use std::collections::VecDeque;
 use std::io::Read;
 
 pub struct MockStream {
-    data: Vec<u8>,
+    data: VecDeque<u8>,
 }
 
 impl MockStream {
-    pub fn with_data(data: Vec<u8>) -> Self {
+    pub fn with_data(data: VecDeque<u8>) -> Self {
         Self { data }
     }
 }
 
 impl Read for MockStream {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let mut index = 0;
+        let mut bytes_written: usize = 0;
+
         for byte in buf {
-            *byte = self.data[index];
-            index += 1;
-            if index == self.data.len() {
-                break;
+            if let Some(new_byte) = self.data.pop_front() {
+                *byte = new_byte;
+                bytes_written += 1;
+            } else {
+                return std::io::Result::Ok(bytes_written);
             }
         }
 
-        std::io::Result::Ok(self.data.len())
+        std::io::Result::Ok(bytes_written)
     }
 }

--- a/humphrey/src/tests/request.rs
+++ b/humphrey/src/tests/request.rs
@@ -4,16 +4,16 @@ use crate::http::headers::RequestHeader;
 use crate::http::method::Method;
 use crate::http::Request;
 use crate::tests::mock_stream::MockStream;
-use std::{
-    collections::BTreeMap,
-    io::Read,
-    net::{SocketAddr, ToSocketAddrs},
-};
+
+use std::collections::{BTreeMap, VecDeque};
+use std::io::Read;
+use std::iter::FromIterator;
+use std::net::{SocketAddr, ToSocketAddrs};
 
 #[test]
 fn test_request_from_stream() {
     let test_data = b"GET /testpath?foo=bar HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    let mut stream = MockStream::with_data(test_data.to_vec());
+    let mut stream = MockStream::with_data(VecDeque::from_iter(test_data.iter().cloned()));
     let request = Request::from_stream(&mut stream, "1.2.3.4:5678".parse().unwrap());
 
     assert!(request.is_ok());
@@ -63,7 +63,7 @@ fn test_bytes_from_request() {
 fn test_proxied_request_from_stream() {
     let test_data =
         b"GET /testpath HTTP/1.1\r\nHost: localhost\r\nX-Forwarded-For: 9.10.11.12,13.14.15.16\r\n\r\n";
-    let mut stream = MockStream::with_data(test_data.to_vec());
+    let mut stream = MockStream::with_data(VecDeque::from_iter(test_data.iter().cloned()));
     let request = Request::from_stream(&mut stream, "1.2.3.4:5678".parse().unwrap());
 
     assert!(request.is_ok());

--- a/humphrey/src/tests/response.rs
+++ b/humphrey/src/tests/response.rs
@@ -3,7 +3,9 @@ use crate::http::headers::{ResponseHeader, ResponseHeaderMap};
 use crate::http::response::Response;
 use crate::http::status::StatusCode;
 use crate::tests::mock_stream::MockStream;
-use std::collections::BTreeMap;
+
+use std::collections::{BTreeMap, VecDeque};
+use std::iter::FromIterator;
 
 #[test]
 fn test_response() {
@@ -38,7 +40,7 @@ fn test_response() {
 #[test]
 fn test_response_from_stream() {
     let test_data = b"HTTP/1.1 404 Not Found\r\nContent-Length: 51\r\n\r\nThe requested resource was not found on the server.\r\n";
-    let mut stream = MockStream::with_data(test_data.to_vec());
+    let mut stream = MockStream::with_data(VecDeque::from_iter(test_data.iter().cloned()));
     let response = Response::from_stream(&mut stream);
 
     assert!(response.is_ok());


### PR DESCRIPTION
Issue #66 detailed how the server is vulnerable to being deadlocked if too many clients hold keep-alive connections indefinitely. This PR implements a configurable timeout to avoid this.