### PR TITLE
Fixed stack overflow bug in JSON parser

### DIFF
--- a/humphrey-json/src/error.rs
+++ b/humphrey-json/src/error.rs
@@ -20,6 +20,8 @@ pub enum ParseError {
     TypeError,
     /// The field was missing.
     MissingField,
+    /// The maximum recursion depth was exceeded.
+    RecursionDepthExceeded,
 }
 
 /// Encapsulates a parse error and its location.


### PR DESCRIPTION
This occurred when parsing a very deeply nested JSON object, such as `[[[[[[[[...` for several thousand characters.