### PR TITLE
Implement new header system

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -15,11 +15,13 @@ jobs:
   examples:
     name: Check Examples
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
       - name: Install stable toolchain
+        if: always()
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -27,90 +29,105 @@ jobs:
           override: true
 
       - name: Check async WebSocket example
+        if: always()
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --manifest-path examples/async-websocket/Cargo.toml
 
       - name: Check auth example
+        if: always()
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --manifest-path examples/auth/Cargo.toml
 
       - name: Check basic example
+        if: always()
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --manifest-path examples/basic/Cargo.toml
 
       - name: Check broadcast example
+        if: always()
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --manifest-path examples/broadcast/Cargo.toml
 
       - name: Check chat app example
+        if: always()
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --manifest-path examples/chat-app/server/Cargo.toml
 
       - name: Check client example
+        if: always()
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --manifest-path examples/client/Cargo.toml
 
       - name: Check database example
+        if: always()
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --manifest-path examples/database/Cargo.toml
 
       - name: Check host example
+        if: always()
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --manifest-path examples/host/Cargo.toml
           
       - name: Check monitor example
+        if: always()
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --manifest-path examples/monitor/Cargo.toml
 
       - name: Check plugin example
+        if: always()
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --manifest-path examples/plugin/Cargo.toml
 
       - name: Check stateful example
+        if: always()
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --manifest-path examples/stateful/Cargo.toml
 
       - name: Check static content example
+        if: always()
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --manifest-path examples/static-content/Cargo.toml
 
       - name: Check TLS example
+        if: always()
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --manifest-path examples/tls/Cargo.toml
 
       - name: Check WebSocket example
+        if: always()
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --manifest-path examples/websocket/Cargo.toml
 
       - name: Check wildcard example
+        if: always()
         uses: actions-rs/cargo@v1
         with:
           command: check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [workspace]
 members = [
   "humphrey",
-  "humphrey-auth",
-  "humphrey-json",
-  "humphrey-server",
-  "humphrey-ws"
+#  "humphrey-auth",
+#  "humphrey-json",
+#  "humphrey-server",
+#  "humphrey-ws"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,11 @@
 [workspace]
 members = [
   "humphrey",
-#  "humphrey-auth",
-#  "humphrey-json",
-#  "humphrey-server",
-#  "humphrey-ws"
+  "humphrey-auth",
+  "humphrey-json",
+  "humphrey-server",
+  "humphrey-ws"
 ]
+
+[patch.crates-io]
+humphrey = { path = "./humphrey" }

--- a/docs/src/core/client.md
+++ b/docs/src/core/client.md
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 Headers can be added to the request by using the `with_header` method on the `ClientRequest` struct. For this example, we'll use the `User-Agent` header to identify the client. Redirects can be followed by using `with_redirects` and specifying to follow redirects.
 
 ```rs
-use humphrey::http::headers::RequestHeader;
+use humphrey::http::headers::HeaderType;
 use humphrey::Client;
 use std::error::Error;
 
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let response = client
         .get("https://api.ipify.org")?
         .with_redirects(true)
-        .with_header(RequestHeader::UserAgent, "HumphreyExample/1.0")
+        .with_header(HeaderType::UserAgent, "HumphreyExample/1.0")
         .send()?;
 
     println!("IP address: {}", response.text().ok_or("Invalid text")?);

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -26,7 +26,7 @@ This book is up-to-date with the following crate versions.
 
 | Crate | Version |
 | ----- | ------- |
-| Humphrey Core | 0.5.4 |
+| Humphrey Core | 0.6.0 |
 | Humphrey Server | 0.5.0 |
 | Humphrey WebSocket | 0.3.0 |
 | Humphrey JSON | 0.1.0 |

--- a/docs/src/server/creating-a-plugin.md
+++ b/docs/src/server/creating-a-plugin.md
@@ -55,7 +55,7 @@ Let's add some code which will intercept all requests to the `/example` route, a
 ```rs
 // --snip--
 
-use humphrey::http::headers::ResponseHeader;
+use humphrey::http::headers::HeaderType;
 use humphrey::http::{Request, Response, StatusCode};
 use humphrey_server::config::RouteConfig;
 use humphrey_server::AppState;
@@ -83,7 +83,7 @@ impl Plugin for MyPlugin {
             return Some(
                 Response::empty(StatusCode::OK)
                     .with_bytes("Hello, world!")
-                    .with_header(ResponseHeader::ContentType, "text/plain".into()),
+                    .with_header(HeaderType::ContentType, "text/plain"),
             );
         }
 
@@ -105,12 +105,7 @@ impl Plugin for MyPlugin {
 
     fn on_response(&self, response: &mut Response, state: Arc<AppState>) {
         // Insert a header to the response
-        response.headers.insert(
-            ResponseHeader::Custom {
-                name: "X-Example-Plugin".into(),
-            },
-            "true".into(),
-        );
+        response.headers.add("X-Example-Plugin", "true");
 
         state
             .logger

--- a/examples/auth/src/main.rs
+++ b/examples/auth/src/main.rs
@@ -3,7 +3,7 @@ mod database;
 use database::WrappedDatabase;
 
 use humphrey::handlers::serve_dir;
-use humphrey::http::headers::ResponseHeader;
+use humphrey::http::headers::HeaderType;
 use humphrey::http::method::Method;
 use humphrey::http::{Request, Response, StatusCode};
 use humphrey::App;
@@ -99,7 +99,7 @@ fn login(request: Request, state: Arc<AppState>) -> Response {
 
                 return Response::empty(StatusCode::OK)
                     .with_header(
-                        ResponseHeader::SetCookie,
+                        HeaderType::SetCookie,
                         format!("HumphreyToken={}; Path=/; MaxAge=3600", token),
                     )
                     .with_bytes(b"OK");
@@ -172,10 +172,10 @@ fn sign_out(_: Request, state: Arc<AppState>, uid: String) -> Response {
     // Return a response which redirects the client to the homepage as well as resets the cookie.
     Response::empty(StatusCode::Found)
         .with_bytes("OK")
-        .with_header(ResponseHeader::Location, "/".into())
+        .with_header(HeaderType::Location, "/")
         .with_header(
-            ResponseHeader::SetCookie,
-            "HumphreyToken=deleted; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT".into(),
+            HeaderType::SetCookie,
+            "HumphreyToken=deleted; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
         )
 }
 
@@ -195,10 +195,10 @@ fn delete_account(_: Request, state: Arc<AppState>, uid: String) -> Response {
     // Return a response which redirects the client to the homepage as well as resets the cookie.
     Response::empty(StatusCode::Found)
         .with_bytes("OK")
-        .with_header(ResponseHeader::Location, "/".into())
+        .with_header(HeaderType::Location, "/")
         .with_header(
-            ResponseHeader::SetCookie,
-            "HumphreyToken=deleted; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT".into(),
+            HeaderType::SetCookie,
+            "HumphreyToken=deleted; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
         )
 }
 
@@ -213,7 +213,7 @@ fn profile(_: Request, state: Arc<AppState>, uid: String) -> Response {
 
     // Return the response.
     Response::empty(StatusCode::OK)
-        .with_header(ResponseHeader::ContentType, "text/html".into())
+        .with_header(HeaderType::ContentType, "text/html")
         .with_bytes(html)
 }
 

--- a/examples/client/src/main.rs
+++ b/examples/client/src/main.rs
@@ -1,4 +1,4 @@
-use humphrey::http::headers::RequestHeader;
+use humphrey::http::headers::HeaderType;
 use humphrey::Client;
 use std::error::Error;
 
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let response = client
         .post("https://jsonplaceholder.typicode.com/posts", data)?
         .with_header(
-            RequestHeader::ContentType,
+            HeaderType::ContentType,
             "application/json; charset=UTF-8",
         )
         .send()?;

--- a/examples/plugin/src/lib.rs
+++ b/examples/plugin/src/lib.rs
@@ -1,4 +1,4 @@
-use humphrey::http::headers::ResponseHeader;
+use humphrey::http::headers::HeaderType;
 use humphrey::http::{Request, Response, StatusCode};
 
 use humphrey_server::config::RouteConfig;
@@ -33,8 +33,8 @@ impl Plugin for ExamplePlugin {
 
             return Some(
                 Response::empty(StatusCode::OK)
-                    .with_bytes(b"Response overridden by example plugin :)".to_vec())
-                    .with_header(ResponseHeader::ContentType, "text/plain".into()),
+                    .with_bytes(b"Response overridden by example plugin :)")
+                    .with_header(HeaderType::ContentType, "text/plain"),
             );
         }
 
@@ -43,12 +43,7 @@ impl Plugin for ExamplePlugin {
 
     fn on_response(&self, response: &mut Response, state: Arc<AppState>) {
         // Insert a header to the response
-        response.headers.insert(
-            ResponseHeader::Custom {
-                name: "X-Example-Plugin".into(),
-            },
-            "true".into(),
-        );
+        response.headers.add("X-Example-Plugin", "true");
 
         state
             .logger

--- a/humphrey-auth/Cargo.toml
+++ b/humphrey-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "humphrey_auth"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/w-henderson/Humphrey"
@@ -11,7 +11,7 @@ keywords = ["authentication"]
 categories = ["authentication"]
 
 [dependencies]
-humphrey = { version = ">=0.4, <0.6" }
+humphrey = { version = "^0.6.0", path = "../humphrey" }
 argon2 = "0.3"
 uuid = { version = "0.8", features = [ "v4" ] }
 rand_core = { version = "0.6", features = ["std"] }

--- a/humphrey-auth/Cargo.toml
+++ b/humphrey-auth/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["authentication"]
 categories = ["authentication"]
 
 [dependencies]
-humphrey = { version = ">=0.4, <0.6", path = "../humphrey" }
+humphrey = { version = ">=0.4, <0.6" }
 argon2 = "0.3"
 uuid = { version = "0.8", features = [ "v4" ] }
 rand_core = { version = "0.6", features = ["std"] }

--- a/humphrey-auth/src/app.rs
+++ b/humphrey-auth/src/app.rs
@@ -3,7 +3,7 @@
 use crate::database::AuthDatabase;
 use crate::AuthProvider;
 
-use humphrey::http::headers::RequestHeader;
+use humphrey::http::headers::HeaderType;
 use humphrey::http::{Request, Response, StatusCode};
 use humphrey::App;
 
@@ -73,7 +73,7 @@ where
         T: AuthRequestHandler<S> + 'static,
     {
         self.with_route(route, move |request: Request, state: Arc<S>| {
-            if let Some(cookie) = request.headers.get(&RequestHeader::Cookie) {
+            if let Some(cookie) = request.headers.get(&HeaderType::Cookie) {
                 let token = cookie
                     .split(';')
                     .find(|s| s.trim().starts_with("HumphreyToken="))

--- a/humphrey-server/Cargo.toml
+++ b/humphrey-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "humphrey_server"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2018"
 license = "MIT"
 homepage = "https://github.com/w-henderson/Humphrey"
@@ -11,7 +11,7 @@ keywords = ["http", "server", "http-server"]
 categories = ["web-programming::http-server", "network-programming", "command-line-utilities"]
 
 [dependencies]
-humphrey = { version = "^0.5.2" }
+humphrey = { version = "^0.6.0", path = "../humphrey" }
 libloading = { version = "0.7", optional = true }
 
 [features]

--- a/humphrey-server/Cargo.toml
+++ b/humphrey-server/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["http", "server", "http-server"]
 categories = ["web-programming::http-server", "network-programming", "command-line-utilities"]
 
 [dependencies]
-humphrey = { version = "^0.5.2", path = "../humphrey" }
+humphrey = { version = "^0.5.2" }
 libloading = { version = "0.7", optional = true }
 
 [features]

--- a/humphrey-server/src/server/proxy.rs
+++ b/humphrey-server/src/server/proxy.rs
@@ -4,7 +4,7 @@ use crate::config::LoadBalancerMode;
 use crate::rand::{Choose, Lcg};
 use crate::server::server::AppState;
 
-use humphrey::http::headers::ResponseHeader;
+use humphrey::http::headers::HeaderType;
 use humphrey::http::proxy::proxy_request;
 use humphrey::http::{Request, Response, StatusCode};
 
@@ -76,7 +76,7 @@ pub fn proxy_handler(
             request.address, request.uri
         ));
         Response::empty(StatusCode::Forbidden)
-            .with_header(ResponseHeader::ContentType, "text/html".into())
+            .with_header(HeaderType::ContentType, "text/html")
             .with_bytes(b"<h1>403 Forbidden</h1>")
     } else {
         // Gets a load balancer target using the thread-safe `Mutex`

--- a/humphrey-server/src/server/static.rs
+++ b/humphrey-server/src/server/static.rs
@@ -2,7 +2,7 @@
 
 use crate::server::server::AppState;
 
-use humphrey::http::headers::ResponseHeader;
+use humphrey::http::headers::HeaderType;
 use humphrey::http::mime::MimeType;
 use humphrey::http::{Request, Response, StatusCode};
 use humphrey::route::{try_find_path, LocatedPath};
@@ -62,7 +62,7 @@ pub fn directory_handler(
                     request.address, request.uri
                 ));
                 Response::empty(StatusCode::MovedPermanently)
-                    .with_header(ResponseHeader::Location, format!("{}/", &request.uri))
+                    .with_header(HeaderType::Location, format!("{}/", &request.uri))
             }
             LocatedPath::File(path) => inner_file_handler(request, state, path, host),
         }
@@ -85,8 +85,7 @@ pub fn redirect_handler(request: Request, state: Arc<AppState>, target: &str) ->
         "{}: 301 Moved Permanently {}",
         request.address, request.uri
     ));
-    Response::empty(StatusCode::MovedPermanently)
-        .with_header(ResponseHeader::Location, target.into())
+    Response::empty(StatusCode::MovedPermanently).with_header(HeaderType::Location, target)
 }
 
 fn inner_file_handler(
@@ -117,7 +116,7 @@ fn inner_file_handler(
         .logger
         .info(&format!("{}: 200 OK {}", request.address, request.uri));
     Response::empty(StatusCode::OK)
-        .with_header(ResponseHeader::ContentType, mime_type.into())
+        .with_header(HeaderType::ContentType, mime_type.to_string())
         .with_bytes(contents)
 }
 
@@ -135,7 +134,7 @@ fn blacklist_check(request: &Request, state: Arc<AppState>) -> Option<Response> 
         ));
         return Some(
             Response::empty(StatusCode::Forbidden)
-                .with_header(ResponseHeader::ContentType, "text/html".into())
+                .with_header(HeaderType::ContentType, "text/html")
                 .with_bytes(b"<h1>403 Forbidden</h1>"),
         );
     }
@@ -153,7 +152,7 @@ fn cache_check(request: &Request, state: Arc<AppState>, host: usize) -> Option<R
             ));
             return Some(
                 Response::empty(StatusCode::OK)
-                    .with_header(ResponseHeader::ContentType, cached.mime_type.into())
+                    .with_header(HeaderType::ContentType, cached.mime_type.to_string())
                     .with_bytes(cached.data.clone()),
             );
         }
@@ -166,6 +165,6 @@ fn cache_check(request: &Request, state: Arc<AppState>, host: usize) -> Option<R
 /// Generates a 404 response.
 pub fn not_found() -> Response {
     Response::empty(StatusCode::NotFound)
-        .with_header(ResponseHeader::ContentType, "text/html".into())
+        .with_header(HeaderType::ContentType, "text/html")
         .with_bytes(b"<h1>404 Not Found</h1>")
 }

--- a/humphrey-ws/Cargo.toml
+++ b/humphrey-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "humphrey_ws"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2018"
 license = "MIT"
 homepage = "https://github.com/w-henderson/Humphrey"
@@ -14,4 +14,4 @@ categories = ["web-programming::websocket", "network-programming"]
 doctest = false
 
 [dependencies]
-humphrey = { version = "^0.5.1" }
+humphrey = { version = "^0.6.0", path = "../humphrey" }

--- a/humphrey-ws/Cargo.toml
+++ b/humphrey-ws/Cargo.toml
@@ -14,4 +14,4 @@ categories = ["web-programming::websocket", "network-programming"]
 doctest = false
 
 [dependencies]
-humphrey = { version = "^0.5.1", path = "../humphrey" }
+humphrey = { version = "^0.5.1" }

--- a/humphrey-ws/src/handler.rs
+++ b/humphrey-ws/src/handler.rs
@@ -6,7 +6,7 @@ use crate::util::base64::Base64Encode;
 use crate::util::sha1::SHA1Hash;
 use crate::MAGIC_STRING;
 
-use humphrey::http::headers::{RequestHeader, ResponseHeader};
+use humphrey::http::headers::HeaderType;
 use humphrey::http::{Request, Response, StatusCode};
 use humphrey::stream::Stream;
 
@@ -110,9 +110,7 @@ fn handshake(request: Request, stream: &mut Stream) -> Result<(), WebsocketError
     // Get the handshake key header
     let handshake_key = request
         .headers
-        .get(&RequestHeader::Custom {
-            name: "sec-websocket-key".into(),
-        })
+        .get("Sec-WebSocket-Key")
         .ok_or(WebsocketError::HandshakeError)?;
 
     // Calculate the handshake response
@@ -120,14 +118,9 @@ fn handshake(request: Request, stream: &mut Stream) -> Result<(), WebsocketError
 
     // Serialise the handshake response
     let response = Response::empty(StatusCode::SwitchingProtocols)
-        .with_header(ResponseHeader::Upgrade, "websocket".into())
-        .with_header(ResponseHeader::Connection, "Upgrade".into())
-        .with_header(
-            ResponseHeader::Custom {
-                name: "Sec-WebSocket-Accept".into(),
-            },
-            sec_websocket_accept,
-        );
+        .with_header(HeaderType::Upgrade, "websocket")
+        .with_header(HeaderType::Connection, "Upgrade")
+        .with_header("Sec-WebSocket-Accept", sec_websocket_accept);
 
     // Transmit the handshake response
     let response_bytes: Vec<u8> = response.into();

--- a/humphrey/Cargo.toml
+++ b/humphrey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "humphrey"
-version = "0.5.5"
+version = "0.6.0"
 edition = "2018"
 license = "MIT"
 homepage = "https://github.com/w-henderson/Humphrey"

--- a/humphrey/src/app.rs
+++ b/humphrey/src/app.rs
@@ -544,7 +544,7 @@ fn client_handler<State>(
 
         // If the request is valid an is a WebSocket request, call the corresponding handler
         if let Ok(req) = &request {
-            if req.headers.get(&HeaderType::Upgrade) == Some(&"websocket".to_string()) {
+            if req.headers.get(&HeaderType::Upgrade) == Some("websocket") {
                 monitor.send(Event::new(EventType::WebsocketConnectionRequested).with_peer(addr));
 
                 call_websocket_handler(req, &subapps, &default_subapp, cloned_state, stream);

--- a/humphrey/src/client.rs
+++ b/humphrey/src/client.rs
@@ -205,7 +205,7 @@ impl Client {
             let (host, path) = stripped.split_once('/').unwrap_or((stripped, ""));
 
             let mut headers = Headers::new();
-            headers.add(HeaderType::Host, host.to_string());
+            headers.add(HeaderType::Host, host);
 
             let host = format!("{}:80", host);
             let host = host.to_socket_addrs().ok()?.next()?;
@@ -224,7 +224,7 @@ impl Client {
             let (host, path) = stripped.split_once('/').unwrap_or((stripped, ""));
 
             let mut headers = Headers::new();
-            headers.add(HeaderType::Host, host.to_string());
+            headers.add(HeaderType::Host, host);
 
             let host = format!("{}:443", host);
             let host = host.to_socket_addrs().ok()?.next()?;

--- a/humphrey/src/handlers.rs
+++ b/humphrey/src/handlers.rs
@@ -1,7 +1,7 @@
 //! Provides a number of useful handlers for Humphrey apps.
 
 use crate::app::error_handler;
-use crate::http::headers::ResponseHeader;
+use crate::http::headers::HeaderType;
 use crate::http::mime::MimeType;
 use crate::http::{Request, Response, StatusCode};
 use crate::route::{try_find_path, LocatedPath};
@@ -23,8 +23,8 @@ pub fn serve_file<T>(file_path: &'static str) -> impl Fn(Request, Arc<T>) -> Res
             if file.read_to_end(&mut buf).is_ok() {
                 return if let Some(extension) = path_buf.extension() {
                     Response::new(StatusCode::OK, buf).with_header(
-                        ResponseHeader::ContentType,
-                        MimeType::from_extension(extension.to_str().unwrap()).into(),
+                        HeaderType::ContentType,
+                        MimeType::from_extension(extension.to_str().unwrap()).to_string(),
                     )
                 } else {
                     Response::new(StatusCode::OK, buf)
@@ -57,8 +57,8 @@ pub fn serve_as_file_path<T>(directory_path: &'static str) -> impl Fn(Request, A
             if file.read_to_end(&mut buf).is_ok() {
                 return if let Some(extension) = path_buf.extension() {
                     Response::new(StatusCode::OK, buf).with_header(
-                        ResponseHeader::ContentType,
-                        MimeType::from_extension(extension.to_str().unwrap()).into(),
+                        HeaderType::ContentType,
+                        MimeType::from_extension(extension.to_str().unwrap()).to_string(),
                     )
                 } else {
                     Response::new(StatusCode::OK, buf)
@@ -88,15 +88,16 @@ pub fn serve_dir<T>(directory_path: &'static str) -> impl Fn(Request, Arc<T>, &s
         if let Some(located) = located {
             match located {
                 LocatedPath::Directory => Response::empty(StatusCode::MovedPermanently)
-                    .with_header(ResponseHeader::Location, format!("{}/", &request.uri)),
+                    .with_header(HeaderType::Location, format!("{}/", &request.uri)),
                 LocatedPath::File(path) => {
                     if let Ok(mut file) = File::open(&path) {
                         let mut buf = Vec::new();
                         if file.read_to_end(&mut buf).is_ok() {
                             return if let Some(extension) = path.extension() {
                                 Response::new(StatusCode::OK, buf).with_header(
-                                    ResponseHeader::ContentType,
-                                    MimeType::from_extension(extension.to_str().unwrap()).into(),
+                                    HeaderType::ContentType,
+                                    MimeType::from_extension(extension.to_str().unwrap())
+                                        .to_string(),
                                 )
                             } else {
                                 Response::new(StatusCode::OK, buf)

--- a/humphrey/src/http/address.rs
+++ b/humphrey/src/http/address.rs
@@ -1,6 +1,6 @@
 //! Provides functionality for parsing and representing network addresses.
 
-use crate::http::headers::{RequestHeader, RequestHeaderMap};
+use crate::http::headers::Headers;
 
 use std::error::Error;
 use std::fmt::Display;
@@ -37,12 +37,10 @@ impl Address {
     /// Create a new `Address` object from a request's headers and the socket address.
     /// This looks for the `X-Forwarded-For` header, used by proxies and CDNs, to find the origin address.
     pub fn from_headers(
-        headers: &RequestHeaderMap,
+        headers: &Headers,
         addr: impl ToSocketAddrs,
     ) -> Result<Self, Box<dyn Error>> {
-        if let Some(forwarded) = headers.get(&RequestHeader::Custom {
-            name: "x-forwarded-for".into(),
-        }) {
+        if let Some(forwarded) = headers.get("X-Forwarded-For") {
             let mut proxies: Vec<IpAddr> = forwarded
                 .split(',')
                 .filter_map(|s| IpAddr::from_str(s).ok())

--- a/humphrey/src/http/mime.rs
+++ b/humphrey/src/http/mime.rs
@@ -84,7 +84,13 @@ impl MimeType {
 
 impl From<MimeType> for String {
     fn from(val: MimeType) -> Self {
-        match val {
+        val.to_string()
+    }
+}
+
+impl ToString for MimeType {
+    fn to_string(&self) -> String {
+        match self {
             MimeType::TextCss => "text/css",
             MimeType::TextHtml => "text/html",
             MimeType::TextJavaScript => "text/javascript",

--- a/humphrey/src/http/proxy.rs
+++ b/humphrey/src/http/proxy.rs
@@ -1,6 +1,5 @@
 //! Provides functionality for HTTP proxying.
 
-use crate::http::headers::RequestHeader;
 use crate::http::response::ResponseError;
 use crate::http::{Request, Response, StatusCode};
 
@@ -27,12 +26,9 @@ fn proxy_request_internal(
         TcpStream::connect_timeout(&target, timeout).map_err(|_| ResponseError::Stream)?;
 
     let mut cloned_request = request.clone();
-    cloned_request.headers.insert(
-        RequestHeader::Custom {
-            name: "X-Forwarded-For".to_string(),
-        },
-        request.address.origin_addr.to_string(),
-    );
+    cloned_request
+        .headers
+        .add("X-Forwarded-For", request.address.origin_addr.to_string());
     let request_bytes: Vec<u8> = cloned_request.into();
     stream
         .write_all(&request_bytes)

--- a/humphrey/src/http/request.rs
+++ b/humphrey/src/http/request.rs
@@ -157,8 +157,7 @@ impl Request {
                     line_parts
                         .next()
                         .to_error(RequestError::Request)?
-                        .trim_start()
-                        .to_string(),
+                        .trim_start(),
                 );
             }
         }

--- a/humphrey/src/http/request.rs
+++ b/humphrey/src/http/request.rs
@@ -1,7 +1,7 @@
 //! Provides functionality for handling HTTP requests.
 
 use crate::http::address::Address;
-use crate::http::headers::{RequestHeader, RequestHeaderMap};
+use crate::http::headers::{HeaderType, Headers};
 use crate::http::method::Method;
 use crate::stream::Stream;
 
@@ -22,8 +22,8 @@ pub struct Request {
     pub query: String,
     /// The HTTP version of the request.
     pub version: String,
-    /// A map of headers included in the request.
-    pub headers: RequestHeaderMap,
+    /// A list of headers included in the request.
+    pub headers: Headers,
     /// The request body, if supplied.
     pub content: Option<Vec<u8>>,
     /// The address from which the request came
@@ -137,7 +137,7 @@ impl Request {
         let uri = uri_iter.next().unwrap().to_string();
         let query = uri_iter.next().unwrap_or("").to_string();
 
-        let mut headers = RequestHeaderMap::new();
+        let mut headers = Headers::new();
 
         loop {
             let mut line_buf: Vec<u8> = Vec::with_capacity(256);
@@ -152,8 +152,8 @@ impl Request {
                 safe_assert(line.len() >= 2)?;
                 let line_without_crlf = &line[0..line.len() - 2];
                 let mut line_parts = line_without_crlf.splitn(2, ':');
-                headers.insert(
-                    RequestHeader::from(line_parts.next().to_error(RequestError::Request)?),
+                headers.add(
+                    HeaderType::from(line_parts.next().to_error(RequestError::Request)?),
                     line_parts
                         .next()
                         .to_error(RequestError::Request)?
@@ -166,7 +166,7 @@ impl Request {
         let address =
             Address::from_headers(&headers, address).map_err(|_| RequestError::Request)?;
 
-        if let Some(content_length) = headers.get(&RequestHeader::ContentLength) {
+        if let Some(content_length) = headers.get(&HeaderType::ContentLength) {
             let content_length: usize =
                 content_length.parse().map_err(|_| RequestError::Request)?;
             let mut content_buf: Vec<u8> = vec![0u8; content_length];
@@ -216,7 +216,7 @@ impl From<Request> for Vec<u8> {
         let headers = req
             .headers
             .iter()
-            .map(|(k, v)| format!("{}: {}", k.to_string(), v))
+            .map(|h| format!("{}: {}", h.name.to_string(), h.value))
             .collect::<Vec<String>>()
             .join("\r\n");
 

--- a/humphrey/src/http/response.rs
+++ b/humphrey/src/http/response.rs
@@ -89,8 +89,7 @@ impl Response {
     where
         T: AsRef<str>,
     {
-        Self::empty(StatusCode::MovedPermanently)
-            .with_header(HeaderType::Location, location.as_ref().to_string())
+        Self::empty(StatusCode::MovedPermanently).with_header(HeaderType::Location, location)
     }
 
     /// Adds the given header to the response.
@@ -158,10 +157,7 @@ impl Response {
                 safe_assert(line.len() >= 2)?;
                 let line_without_crlf = &line[0..line.len() - 2];
                 let line_parts: Vec<&str> = line_without_crlf.splitn(2, ':').collect();
-                headers.add(
-                    HeaderType::from(line_parts[0]),
-                    line_parts[1].trim_start().to_string(),
-                );
+                headers.add(HeaderType::from(line_parts[0]), line_parts[1].trim_start());
             }
         }
 

--- a/humphrey/src/http/response.rs
+++ b/humphrey/src/http/response.rs
@@ -19,7 +19,7 @@ use std::io::{BufRead, BufReader, Read};
 /// ```
 /// Response::empty(StatusCode::OK)
 ///     .with_bytes(b"Success")
-///     .with_header(ResponseHeader::ContentType, "text/plain".into())
+///     .with_header(HeaderType::ContentType, "text/plain")
 /// ```
 #[derive(Debug)]
 pub struct Response {

--- a/humphrey/src/tests/client.rs
+++ b/humphrey/src/tests/client.rs
@@ -1,5 +1,5 @@
 use crate::client::{Client, ParsedUrl, Protocol};
-use crate::http::headers::{RequestHeader, RequestHeaderMap};
+use crate::http::headers::{HeaderType, Headers};
 
 use std::net::ToSocketAddrs;
 
@@ -15,8 +15,8 @@ fn test_url_parser() {
         Client::parse_url("https://google.com/search?q=test").unwrap(),
     ];
 
-    let mut expected_host_headers = RequestHeaderMap::new();
-    expected_host_headers.insert(RequestHeader::Host, "google.com".to_string());
+    let mut expected_host_headers = Headers::new();
+    expected_host_headers.add(HeaderType::Host, "google.com");
 
     let expected_urls = [
         ParsedUrl {

--- a/humphrey/src/tests/response.rs
+++ b/humphrey/src/tests/response.rs
@@ -1,5 +1,5 @@
 #![allow(unused_imports)]
-use crate::http::headers::{ResponseHeader, ResponseHeaderMap};
+use crate::http::headers::{HeaderType, Headers};
 use crate::http::response::Response;
 use crate::http::status::StatusCode;
 use crate::tests::mock_stream::MockStream;
@@ -11,22 +11,19 @@ use std::iter::FromIterator;
 fn test_response() {
     let response = Response::empty(StatusCode::OK)
         .with_bytes(b"<body>test</body>")
-        .with_header(ResponseHeader::ContentType, "text/html".to_string())
-        .with_header(ResponseHeader::ContentLanguage, "en-GB".to_string())
-        .with_header(
-            ResponseHeader::Date,
-            "Thu, 1 Jan 1970 00:00:00 GMT".to_string(),
-        ); // this would never be manually set in prod, but is obviously required for testing
+        .with_header(HeaderType::ContentType, "text/html")
+        .with_header(HeaderType::ContentLanguage, "en-GB")
+        .with_header(HeaderType::Date, "Thu, 1 Jan 1970 00:00:00 GMT"); // this would never be manually set in prod, but is obviously required for testing
 
     assert!(response
         .get_headers()
-        .get(&ResponseHeader::ContentType)
+        .get(&HeaderType::ContentType)
         .is_some());
 
     assert_eq!(
         response
             .get_headers()
-            .get(&ResponseHeader::ContentType)
+            .get(&HeaderType::ContentType)
             .unwrap(),
         "text/html"
     );
@@ -51,7 +48,7 @@ fn test_response_from_stream() {
     assert_eq!(response.version, "HTTP/1.1".to_string());
     assert_eq!(response.status_code, StatusCode::NotFound);
 
-    let mut expected_headers: BTreeMap<ResponseHeader, String> = BTreeMap::new();
-    expected_headers.insert(ResponseHeader::ContentLength, "51".into());
+    let mut expected_headers: Headers = Headers::new();
+    expected_headers.add(HeaderType::ContentLength, "51");
     assert_eq!(response.headers, expected_headers);
 }


### PR DESCRIPTION
The new system will be more flexible for developers to use and will allow multiple headers with the same names (e.g. `Set-Cookie`). As well as being implemented, it needs to be documented and the examples need to be updated to use it.