### PR TITLE
Added support for state at the WebSocket stream level

### DIFF
--- a/humphrey-ws/Cargo.toml
+++ b/humphrey-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "humphrey_ws"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2018"
 license = "MIT"
 homepage = "https://github.com/w-henderson/Humphrey"


### PR DESCRIPTION
Individual async streams can now have their own state, stored with the socket object in the WS app.