### PR TITLE
Make humphrey stoppable

### DIFF
--- a/examples/basic_stoppable/Cargo.toml
+++ b/examples/basic_stoppable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "basic"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+humphrey = { path = "../../humphrey" }
+
+[workspace]

--- a/examples/basic_stoppable/src/main.rs
+++ b/examples/basic_stoppable/src/main.rs
@@ -1,0 +1,40 @@
+use humphrey::http::{Request, Response, StatusCode};
+use humphrey::App;
+use std::error::Error;
+
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let app: App<()> = App::new()
+        .with_shutdown(shutdown.clone())
+        .with_stateless_route("/", home)
+        .with_stateless_route("/contact", contact)
+        .with_stateless_route("/*", generic);
+    
+    std::thread::spawn(move || {
+        if let Err(err) = app.run("0.0.0.0:80") { println!("{err}")}
+        println!("app done");
+    });
+
+    std::thread::sleep(std::time::Duration::from_secs(5));
+    shutdown.store(true, Ordering::Relaxed);
+    Ok(())
+}
+
+fn home(_: Request) -> Response {
+    Response::new(StatusCode::OK, "<html><body><h1>Home</h1></body></html>")
+}
+
+fn contact(_: Request) -> Response {
+    Response::new(StatusCode::OK, "<html><body><h1>Contact</h1></body></html>")
+}
+
+fn generic(request: Request) -> Response {
+    let html = format!(
+        "<html><body><h1>You just requested {}.</h1></body></html>",
+        request.uri
+    );
+
+    Response::new(StatusCode::OK, html)
+}

--- a/examples/basic_stoppable/src/main.rs
+++ b/examples/basic_stoppable/src/main.rs
@@ -1,5 +1,5 @@
 use humphrey::http::{Request, Response, StatusCode};
-use humphrey::App;
+use humphrey::{handlers, App};
 use std::error::Error;
 
 use std::sync::{Arc, atomic::{AtomicBool, Ordering}};

--- a/humphrey/Cargo.toml
+++ b/humphrey/Cargo.toml
@@ -43,3 +43,9 @@ tokio = ["dep:tokio", "futures", "tokio-rustls"]
 
 [lib]
 doctest = false
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["winsock2"] }

--- a/humphrey/src/app.rs
+++ b/humphrey/src/app.rs
@@ -237,6 +237,7 @@ where
             libc::close(socket.as_raw_fd());
         }
 		self.thread_pool.stop();
+        drop(self.thread_pool);
         Ok(())
     }
 

--- a/humphrey/src/thread/recovery.rs
+++ b/humphrey/src/thread/recovery.rs
@@ -14,7 +14,9 @@ pub struct PanicMarker(pub usize, pub Sender<Option<usize>>);
 
 /// Manages the recovery thread.
 pub struct RecoveryThread {
+    /// handle
     pub handle: Option<JoinHandle<()>>,
+    /// Sends a number of a thread or None to shutdown
     pub tx: Sender<Option<usize>>,
 }
 
@@ -65,7 +67,7 @@ impl RecoveryThread {
 
         let thread = spawn({
             let tx = tx.clone(); 
-            move || loop {
+            move || {
             for panicking_thread in &rx {
                 if let Some(panicking_thread) = panicking_thread {
                     let mut threads = threads.lock().unwrap();
@@ -98,7 +100,8 @@ impl RecoveryThread {
                     break;
                 }
             }
-        }});
+        }
+    });
 
         Self {
             handle: Some(thread), tx


### PR DESCRIPTION
Currently, run or run_tls run forever. For some use cases, it might be useful to be able to stop the server. I therefore added an optional flag to stop the server when set to true. It can be added using app.with_shutdown(flag: AtomicBool). For usage, take a look at the provided example in examples/basic_stoppable
I hope this is useful and gets accepted.
Best regards,
Daniel