### PR TITLE
Resolver 2 and clippy complaints

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,19 @@ jobs:
     name: Check Crates
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+      - name: Install MSRV Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.60.0
+      - uses: Swatinem/rust-cache@v2
+      - name: "check MSRV"
+        run: cargo check
+
+  msrv:
+    name: Check MSRV
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "humphrey-server",
   "humphrey-ws"
 ]
+resolver = "2"
 
 [patch.crates-io]
 humphrey = { path = "./humphrey" }

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 <hr><br>
 
-Humphrey is a very fast, robust and flexible HTTP/1.1 web server, with support for static and dynamic content through its Rust crate and plugin system. It has no dependencies when only using default features, and the binary is easily extensible with a flexible configuration file and dynamically-loaded plugins. It also provides a WebSocket API for the easy integration of WebSockets into your application, a JSON manipulation crate, and a simple authentication system for authenticating users and managing sessions.
+Humphrey is a very fast, robust and flexible HTTP/1.1 web server, with support for static and dynamic content through its Rust crate and plugin system. It has no dependencies when only using default features, and the binary is easily extensible with a flexible configuration file and dynamically-loaded plugins. It also provides a WebSocket API for the easy integration of WebSockets into your application, a JSON manipulation crate, and a simple authentication system for authenticating users and managing sessions. The current Minimum Supported Rust Version is 1.60.
 
 ## Quick Links
 - [Use Humphrey as a crate](https://humphrey.whenderson.dev/core/index.html)

--- a/docs/src/server/creating-a-plugin.md
+++ b/docs/src/server/creating-a-plugin.md
@@ -16,7 +16,7 @@ Then, in the `Cargo.toml` file, you'll need to specify the `humphrey` and `humph
 [package]
 name = "my_plugin"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 humphrey = "*"

--- a/examples/async-websocket/Cargo.toml
+++ b/examples/async-websocket/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "async_websocket"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "basic"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/broadcast/Cargo.toml
+++ b/examples/broadcast/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "broadcast"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/client/Cargo.toml
+++ b/examples/client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/cors/Cargo.toml
+++ b/examples/cors/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cors"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/database/Cargo.toml
+++ b/examples/database/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "database"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/host/Cargo.toml
+++ b/examples/host/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "host"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/monitor/Cargo.toml
+++ b/examples/monitor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "monitor"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/plugin/Cargo.toml
+++ b/examples/plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plugin"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/stateful-tokio/Cargo.toml
+++ b/examples/stateful-tokio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stateful"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/stateful/Cargo.toml
+++ b/examples/stateful/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stateful"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/static-content-tokio/Cargo.toml
+++ b/examples/static-content-tokio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "static-content"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/static-content/Cargo.toml
+++ b/examples/static-content/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "static-content"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/tls-tokio/Cargo.toml
+++ b/examples/tls-tokio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tls"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/tls/Cargo.toml
+++ b/examples/tls/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tls"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/websocket/Cargo.toml
+++ b/examples/websocket/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "websocket"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/wildcard/Cargo.toml
+++ b/examples/wildcard/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wildcard"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/humphrey-json-derive/src/tuple_struct.rs
+++ b/humphrey-json-derive/src/tuple_struct.rs
@@ -34,7 +34,7 @@ pub fn from_json_tuple_struct(ast: DeriveInput, r#struct: &DataStruct) -> TokenS
 /// Derives the `IntoJson` trait for a tuple struct.
 pub fn into_json_tuple_struct(ast: DeriveInput, r#struct: &DataStruct) -> TokenStream {
     let field_count = r#struct.fields.len();
-    let field_iter = (0..field_count).into_iter().map(Index::from);
+    let field_iter = (0..field_count).map(Index::from);
 
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();

--- a/humphrey-json/src/tests/spec/mod.rs
+++ b/humphrey-json/src/tests/spec/mod.rs
@@ -2,8 +2,7 @@
 //! Tests beginning with `y` should be successfully parsed.
 //! Tests beginning with `n` should throw an error but not panic.
 
-#![allow(non_upper_case_globals)]
-#![allow(non_snake_case)]
+#![allow(invalid_from_utf8, non_snake_case, non_upper_case_globals)]
 
 macro_rules! create_test {
     ($($name:ident: $path:literal,)+) => {

--- a/humphrey-server/Cargo.toml
+++ b/humphrey-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "humphrey_server"
 version = "0.6.1"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 homepage = "https://github.com/w-henderson/Humphrey"
 repository = "https://github.com/w-henderson/Humphrey"

--- a/humphrey-server/src/main.rs
+++ b/humphrey-server/src/main.rs
@@ -10,7 +10,7 @@ fn main() {
         Ok(config) => server::main(config),
         Err(error) => {
             let logger = Logger::default();
-            logger.error(&error);
+            logger.error(error);
         }
     }
 }

--- a/humphrey-server/src/server/proxy.rs
+++ b/humphrey-server/src/server/proxy.rs
@@ -71,7 +71,7 @@ pub fn proxy_handler(
         .list
         .contains(&request.address.origin_addr)
     {
-        state.logger.warn(&format!(
+        state.logger.warn(format!(
             "{}: Blacklisted IP attempted to request {}",
             request.address, request.uri
         ));
@@ -92,7 +92,7 @@ pub fn proxy_handler(
         let status: u16 = response.status_code.into();
         let status_string: &str = response.status_code.into();
 
-        state.logger.info(&format!(
+        state.logger.info(format!(
             "{}: {} {} {}",
             request.address, status, status_string, request.uri
         ));

--- a/humphrey-server/src/server/server.rs
+++ b/humphrey-server/src/server/server.rs
@@ -86,7 +86,7 @@ pub fn main(config: Config) {
             .with_forced_https(tls_config.force);
 
         if state.config.port != 443 {
-            state.logger.warn(&format!(
+            state.logger.warn(format!(
                 "HTTPS is typically served on port 443, so your setting of {} may cause issues.",
                 state.config.port,
             ));
@@ -114,18 +114,18 @@ pub fn main(config: Config) {
         }
     }
 
-    logger.debug(&format!("Configuration: {:?}", state.config));
+    logger.debug(format!("Configuration: {:?}", state.config));
 
     logger.info("Starting server");
 
     #[cfg(feature = "plugins")]
     if let Ok(plugins_count) = load_plugins(&state.config, state.clone()) {
-        logger.info(&format!("Loaded {} plugins", plugins_count))
+        logger.info(format!("Loaded {} plugins", plugins_count))
     } else {
         exit(1);
     };
 
-    logger.info(&format!("Running at {}", addr));
+    logger.info(format!("Running at {}", addr));
 
     #[cfg(feature = "tls")]
     if state.config.tls_config.is_some() {
@@ -162,7 +162,7 @@ fn verify_connection(stream: &mut TcpStream, state: Arc<AppState>) -> bool {
         if state.config.blacklist.mode == BlacklistMode::Block
             && state.config.blacklist.list.contains(&address.ip())
         {
-            state.logger.warn(&format!(
+            state.logger.warn(format!(
                 "{}: Blacklisted IP attempted to connect",
                 &address.ip()
             ));
@@ -301,7 +301,7 @@ fn proxy_websocket(
 
         destination.write_all(&bytes)?;
 
-        state.logger.info(&format!(
+        state.logger.info(format!(
             "{}: WebSocket connected, proxying data",
             source_addr
         ));
@@ -338,7 +338,7 @@ fn proxy_websocket(
     } else {
         state
             .logger
-            .error(&format!("{}: Could not connect to WebSocket", source_addr));
+            .error(format!("{}: Could not connect to WebSocket", source_addr));
     }
 
     Ok(())
@@ -355,20 +355,20 @@ fn load_plugins(config: &Config, state: Arc<AppState>) -> Result<usize, ()> {
             #[allow(clippy::significant_drop_in_scrutinee)]
             match manager.load_plugin(&plugin.library, &plugin.config, app_state) {
                 PluginLoadResult::Ok(name) => {
-                    state.logger.info(&format!("Initialised plugin {}", name));
+                    state.logger.info(format!("Initialised plugin {}", name));
                 }
                 PluginLoadResult::NonFatal(e) => {
                     state
                         .logger
-                        .warn(&format!("Non-fatal plugin error in {}", plugin.name));
-                    state.logger.warn(&format!("Error message: {}", e));
+                        .warn(format!("Non-fatal plugin error in {}", plugin.name));
+                    state.logger.warn(format!("Error message: {}", e));
                     state.logger.warn("Ignoring this plugin");
                 }
                 PluginLoadResult::Fatal(e) => {
                     state
                         .logger
-                        .error(&format!("Could not initialise plugin {}", plugin.name));
-                    state.logger.error(&format!("Error message: {}", e));
+                        .error(format!("Could not initialise plugin {}", plugin.name));
+                    state.logger.error(format!("Error message: {}", e));
 
                     return Err(());
                 }

--- a/humphrey-server/src/server/static.rs
+++ b/humphrey-server/src/server/static.rs
@@ -57,7 +57,7 @@ pub fn directory_handler(
     if let Some(located) = try_find_path(directory, &simplified_uri, &INDEX_FILES) {
         match located {
             LocatedPath::Directory => {
-                state.logger.info(&format!(
+                state.logger.info(format!(
                     "{}: 301 Moved Permanently {}",
                     request.address, request.uri
                 ));
@@ -67,7 +67,7 @@ pub fn directory_handler(
             LocatedPath::File(path) => inner_file_handler(request, state, path, host),
         }
     } else {
-        state.logger.warn(&format!(
+        state.logger.warn(format!(
             "{}: 404 Not Found {}",
             request.address, request.uri
         ));
@@ -81,7 +81,7 @@ pub fn redirect_handler(request: Request, state: Arc<AppState>, target: &str) ->
         return response;
     }
 
-    state.logger.info(&format!(
+    state.logger.info(format!(
         "{}: 301 Moved Permanently {}",
         request.address, request.uri
     ));
@@ -105,16 +105,16 @@ fn inner_file_handler(
     if state.config.cache.size_limit >= contents.len() {
         let mut cache = state.cache.write().unwrap();
         cache.set(&request.uri, host, contents.clone(), mime_type);
-        state.logger.debug(&format!("Cached route {}", request.uri));
+        state.logger.debug(format!("Cached route {}", request.uri));
     } else if state.config.cache.size_limit > 0 {
         state
             .logger
-            .warn(&format!("Couldn't cache, cache too small {}", request.uri));
+            .warn(format!("Couldn't cache, cache too small {}", request.uri));
     }
 
     state
         .logger
-        .info(&format!("{}: 200 OK {}", request.address, request.uri));
+        .info(format!("{}: 200 OK {}", request.address, request.uri));
     Response::empty(StatusCode::OK)
         .with_header(HeaderType::ContentType, mime_type.to_string())
         .with_bytes(contents)
@@ -128,7 +128,7 @@ fn blacklist_check(request: &Request, state: Arc<AppState>) -> Option<Response> 
         .list
         .contains(&request.address.origin_addr)
     {
-        state.logger.warn(&format!(
+        state.logger.warn(format!(
             "{}: Blacklisted IP attempted to request {}",
             request.address, request.uri
         ));
@@ -146,7 +146,7 @@ fn cache_check(request: &Request, state: Arc<AppState>, host: usize) -> Option<R
     if state.config.cache.size_limit > 0 {
         let cache = state.cache.read().unwrap();
         if let Some(cached) = cache.get(&request.uri, host) {
-            state.logger.info(&format!(
+            state.logger.info(format!(
                 "{}: 200 OK (cached) {}",
                 request.address, request.uri
             ));

--- a/humphrey-ws/Cargo.toml
+++ b/humphrey-ws/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "humphrey_ws"
 version = "0.5.1"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 homepage = "https://github.com/w-henderson/Humphrey"
 repository = "https://github.com/w-henderson/Humphrey"

--- a/humphrey-ws/src/frame.rs
+++ b/humphrey-ws/src/frame.rs
@@ -182,7 +182,7 @@ impl From<Frame> for Vec<u8> {
             buf.extend_from_slice(&(f.length as u16).to_be_bytes());
         } else {
             buf[1] = (f.mask as u8) << 7 | 127;
-            buf.extend_from_slice(&(f.length as u64).to_be_bytes());
+            buf.extend_from_slice(&(f.length).to_be_bytes());
         }
 
         // Add the masking key (if required)

--- a/humphrey/Cargo.toml
+++ b/humphrey/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "humphrey"
 version = "0.7.0"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 homepage = "https://github.com/w-henderson/Humphrey"
 repository = "https://github.com/w-henderson/Humphrey"

--- a/humphrey/src/http/headers.rs
+++ b/humphrey/src/http/headers.rs
@@ -230,17 +230,17 @@ pub enum HeaderType {
 
 impl PartialOrd for HeaderType {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        if self.category() != other.category() {
-            self.category().partial_cmp(&other.category())
-        } else {
-            self.to_string().partial_cmp(&other.to_string())
-        }
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for HeaderType {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
+        if self.category() != other.category() {
+            self.category().cmp(&other.category())
+        } else {
+            self.to_string().cmp(&other.to_string())
+        }
     }
 }
 

--- a/plugins/php/Cargo.toml
+++ b/plugins/php/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "php"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
While digging around the source code, my editor's configuration was getting very confused and spitting out lots of errors. The core problem was virtual workspace resolver conflicts. Doing `cargo build` (isolated example) outputs this

```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
```

I noticed some packages were using 2018 and some were using 2021. I've updated them all to 2021. If you had a differing opinion on MSRV, I also verified `resolver = "1"` works and fixes the original problem.

I have my editor set to be a bit too annoying, perhaps, but it gets me to keep things clean. I also fixed some clippy lints as of 1.74.1. No functional changes intended on either commit.