### PR TITLE
Add CI runner for `pull_request`.

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,16 +1,14 @@
 on:
   push:
-    paths:
-    - "humphrey/**"
-    - "humphrey-auth/**"
-    - "humphrey-json/**"
-    - "humphrey-json-derive/**"
-    - "humphrey-server/**"
-    - "humphrey-ws/**"
-    - "examples/**"
-    - ".github/**"
+    branches: [master, main]
+
+  pull_request:
+    branches: [master, main]
 
 name: Examples
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   examples:
@@ -91,7 +89,7 @@ jobs:
         with:
           command: check
           args: --manifest-path examples/host/Cargo.toml
-          
+
       - name: Check monitor example
         if: always()
         uses: actions-rs/cargo@v1

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1,10 +1,14 @@
 on:
   push:
-    paths:
-    - "plugins/**"
-    - ".github/**"
+    branches: [master, main]
+
+  pull_request:
+    branches: [master, main]
 
 name: Plugins
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   check:

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,11 +1,22 @@
 on:
   push:
+    branches: [master, main]
+    paths:
+    - "humphrey-json/**"
+    - "humphrey-json-derive/**"
+    - ".github/workflows/spec.yml"
+
+  pull_request:
+    branches: [master, main]
     paths:
     - "humphrey-json/**"
     - "humphrey-json-derive/**"
     - ".github/workflows/spec.yml"
 
 name: JSON Specification Compliance
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,14 @@
 on:
   push:
-    paths:
-    - "humphrey/**"
-    - "humphrey-auth/**"
-    - "humphrey-json/**"
-    - "humphrey-json-derive/**"
-    - "humphrey-server/**"
-    - "humphrey-ws/**"
-    - ".github/**"
+    branches: [master, main]
+
+  pull_request:
+    branches: [master, main]
 
 name: CI
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   check:


### PR DESCRIPTION
It would be nice to have Github show CI runners right in the PRs.

I removed the `paths` bit because I don't think it's needed?