### PR TITLE
`with_shutdown` for Tokio app

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           command: check
           args: --manifest-path examples/host/Cargo.toml
-          
+
       - name: Check monitor example
         if: always()
         uses: actions-rs/cargo@v1
@@ -168,3 +168,10 @@ jobs:
         with:
           command: check
           args: --manifest-path examples/shutdown/Cargo.toml
+
+      - name: Check shutdown-tokio example
+        if: always()
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path examples/shutdown-tokio/Cargo.toml

--- a/examples/shutdown-tokio/Cargo.toml
+++ b/examples/shutdown-tokio/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "shutdown-tokio"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+humphrey = { path = "../../humphrey", features = ["tokio"] }
+tokio = { version = "1", features = ["full"] }
+tokio-util = "0.7"
+
+[workspace]

--- a/examples/shutdown-tokio/src/main.rs
+++ b/examples/shutdown-tokio/src/main.rs
@@ -1,0 +1,30 @@
+use humphrey::http::{Request, Response, StatusCode};
+use humphrey::App;
+use tokio_util::sync::CancellationToken;
+
+use std::error::Error;
+use std::thread::{sleep, spawn};
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let cancel = CancellationToken::new();
+    let app: App<()> = App::new()
+        .with_shutdown(cancel.clone())
+        .with_stateless_route("/", hello);
+
+    // Shutdown the main app after 5 seconds
+    spawn(move || {
+        sleep(Duration::from_secs(5));
+        cancel.cancel();
+    });
+
+    // Returns after shutdown signal
+    app.run("0.0.0.0:8080").await?;
+
+    Ok(())
+}
+
+async fn hello(_: Request) -> Response {
+    Response::new(StatusCode::OK, "Hello, world! - tokio")
+}

--- a/examples/shutdown/src/main.rs
+++ b/examples/shutdown/src/main.rs
@@ -13,7 +13,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .with_shutdown(app_rx)
         .with_stateless_route("/hello", |_| Response::new(StatusCode::OK, "Hello world!"));
 
-    // Shutdown both the main app after 5 seconds
+    // Shutdown the main app after 5 seconds
     spawn(move || {
         sleep(Duration::from_secs(5));
         let _ = shutdown_app.send(());

--- a/humphrey/Cargo.toml
+++ b/humphrey/Cargo.toml
@@ -37,9 +37,13 @@ optional = true
 version = "^0.24.1"
 optional = true
 
+[dependencies.tokio-util]
+version = "0.7"
+optional = true
+
 [features]
 tls = ["rustls", "rustls-native-certs", "rustls-pemfile"]
-tokio = ["dep:tokio", "futures", "tokio-rustls"]
+tokio = ["dep:tokio", "futures", "tokio-rustls", "tokio-util"]
 
 [lib]
 doctest = false

--- a/humphrey/src/tokio/app.rs
+++ b/humphrey/src/tokio/app.rs
@@ -134,7 +134,7 @@ where
 
         loop {
             let shutdown = async {
-                if let Some(sd) = self.shutdown.clone() {
+                if let Some(sd) = self.shutdown.as_ref() {
                     sd.cancelled().await
                 } else {
                     futures::future::pending().await
@@ -220,7 +220,7 @@ where
 
         loop {
             let shutdown = async {
-                if let Some(sd) = self.shutdown.clone() {
+                if let Some(sd) = self.shutdown.as_ref() {
                     sd.cancelled().await
                 } else {
                     futures::future::pending().await

--- a/humphrey/src/tokio/app.rs
+++ b/humphrey/src/tokio/app.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
+use tokio_util::sync::CancellationToken;
 
 #[cfg(feature = "tls")]
 use rustls::ServerConfig;
@@ -42,6 +43,7 @@ where
     tls_config: Option<Arc<ServerConfig>>,
     #[cfg(feature = "tls")]
     force_https: bool,
+    shutdown: Option<CancellationToken>,
 }
 
 /// Represents a function able to calculate whether a connection will be accepted.
@@ -98,6 +100,7 @@ where
             tls_config: None,
             #[cfg(feature = "tls")]
             force_https: false,
+            shutdown: None,
         }
     }
 
@@ -114,6 +117,7 @@ where
             tls_config: None,
             #[cfg(feature = "tls")]
             force_https: false,
+            shutdown: None,
         }
     }
 
@@ -129,51 +133,63 @@ where
         let error_handler = Arc::new(self.error_handler);
 
         loop {
-            match socket.accept().await {
-                Ok((mut stream, _)) => {
-                    let cloned_state = self.state.clone();
+            let shutdown = async {
+                if let Some(sd) = self.shutdown.clone() {
+                    sd.cancelled().await
+                } else {
+                    futures::future::pending().await
+                }
+            };
+            tokio::select! {
+                () = shutdown => { break Ok(()); }
+                s = socket.accept() => {
+                    match s {
+                        Ok((mut stream, _)) => {
+                            let cloned_state = self.state.clone();
 
-                    // Check that the client is allowed to connect
-                    if (self.connection_condition)(&mut stream, cloned_state) {
-                        let cloned_state = self.state.clone();
-                        let cloned_monitor = self.monitor.clone();
-                        let cloned_subapps = subapps.clone();
-                        let cloned_default_subapp = default_subapp.clone();
-                        let cloned_error_handler = error_handler.clone();
+                            // Check that the client is allowed to connect
+                            if (self.connection_condition)(&mut stream, cloned_state) {
+                                let cloned_state = self.state.clone();
+                                let cloned_monitor = self.monitor.clone();
+                                let cloned_subapps = subapps.clone();
+                                let cloned_default_subapp = default_subapp.clone();
+                                let cloned_error_handler = error_handler.clone();
 
-                        cloned_monitor.send(
-                            Event::new(EventType::ConnectionSuccess)
-                                .with_peer_result(stream.peer_addr()),
-                        );
+                                cloned_monitor.send(
+                                    Event::new(EventType::ConnectionSuccess)
+                                        .with_peer_result(stream.peer_addr()),
+                                );
 
-                        // Spawn a new thread to handle the connection
-                        tokio::spawn(async move {
-                            cloned_monitor.send(
-                                Event::new(EventType::ThreadPoolProcessStarted)
-                                    .with_peer_result(stream.peer_addr()),
-                            );
+                                // Spawn a new thread to handle the connection
+                                tokio::spawn(async move {
+                                    cloned_monitor.send(
+                                        Event::new(EventType::ThreadPoolProcessStarted)
+                                            .with_peer_result(stream.peer_addr()),
+                                    );
 
-                            client_handler(
-                                Stream::Tcp(stream),
-                                cloned_subapps,
-                                cloned_default_subapp,
-                                cloned_error_handler,
-                                cloned_state,
-                                cloned_monitor,
-                            )
-                            .await
-                        });
-                    } else {
-                        self.monitor.send(
-                            Event::new(EventType::ConnectionDenied)
-                                .with_peer_result(stream.peer_addr()),
-                        );
+                                    client_handler(
+                                        Stream::Tcp(stream),
+                                        cloned_subapps,
+                                        cloned_default_subapp,
+                                        cloned_error_handler,
+                                        cloned_state,
+                                        cloned_monitor,
+                                    )
+                                        .await
+                                });
+                            } else {
+                                self.monitor.send(
+                                    Event::new(EventType::ConnectionDenied)
+                                        .with_peer_result(stream.peer_addr()),
+                                );
+                            }
+                        }
+                        Err(e) => self
+                            .monitor
+                            .send(Event::new(EventType::ConnectionError).with_info(e.to_string())),
                     }
                 }
-                Err(e) => self
-                    .monitor
-                    .send(Event::new(EventType::ConnectionError).with_info(e.to_string())),
-            }
+            };
         }
     }
 
@@ -203,60 +219,73 @@ where
         let acceptor = TlsAcceptor::from(tls_config);
 
         loop {
-            match socket.accept().await {
-                Ok((mut sock, _)) => {
-                    let cloned_state = self.state.clone();
+            let shutdown = async {
+                if let Some(sd) = self.shutdown.clone() {
+                    sd.cancelled().await
+                } else {
+                    futures::future::pending().await
+                }
+            };
 
-                    // Check that the client is allowed to connect
-                    if (self.connection_condition)(&mut sock, cloned_state) {
-                        let cloned_state = self.state.clone();
-                        let cloned_subapps = subapps.clone();
-                        let cloned_default_subapp = default_subapp.clone();
-                        let cloned_error_handler = error_handler.clone();
-                        let cloned_monitor = self.monitor.clone();
-                        let cloned_acceptor = acceptor.clone();
+            tokio::select! {
+                () = shutdown => { break Ok(()); }
+                 s = socket.accept() => {
+                    match s {
+                        Ok((mut sock, _)) => {
+                            let cloned_state = self.state.clone();
 
-                        cloned_monitor.send(
-                            Event::new(EventType::ConnectionSuccess)
-                                .with_peer_result(sock.peer_addr()),
-                        );
+                            // Check that the client is allowed to connect
+                            if (self.connection_condition)(&mut sock, cloned_state) {
+                                let cloned_state = self.state.clone();
+                                let cloned_subapps = subapps.clone();
+                                let cloned_default_subapp = default_subapp.clone();
+                                let cloned_error_handler = error_handler.clone();
+                                let cloned_monitor = self.monitor.clone();
+                                let cloned_acceptor = acceptor.clone();
 
-                        // Spawn a new thread to handle the connection
-                        tokio::spawn(async move {
-                            cloned_monitor.send(
-                                Event::new(EventType::ThreadPoolProcessStarted)
-                                    .with_peer_result(sock.peer_addr()),
-                            );
+                                cloned_monitor.send(
+                                    Event::new(EventType::ConnectionSuccess)
+                                        .with_peer_result(sock.peer_addr()),
+                                );
 
-                            match cloned_acceptor.accept(sock).await {
-                                Ok(tls_stream) => {
-                                    let stream = Stream::Tls(tls_stream);
+                                // Spawn a new thread to handle the connection
+                                tokio::spawn(async move {
+                                    cloned_monitor.send(
+                                        Event::new(EventType::ThreadPoolProcessStarted)
+                                            .with_peer_result(sock.peer_addr()),
+                                    );
 
-                                    client_handler(
-                                        stream,
-                                        cloned_subapps,
-                                        cloned_default_subapp,
-                                        cloned_error_handler,
-                                        cloned_state,
-                                        cloned_monitor,
-                                    )
-                                    .await
-                                }
-                                Err(e) => cloned_monitor.send(
-                                    Event::new(EventType::ConnectionError).with_info(e.to_string()),
-                                ),
+                                    match cloned_acceptor.accept(sock).await {
+                                        Ok(tls_stream) => {
+                                            let stream = Stream::Tls(tls_stream);
+
+                                            client_handler(
+                                                stream,
+                                                cloned_subapps,
+                                                cloned_default_subapp,
+                                                cloned_error_handler,
+                                                cloned_state,
+                                                cloned_monitor,
+                                            )
+                                                .await
+                                        }
+                                        Err(e) => cloned_monitor.send(
+                                            Event::new(EventType::ConnectionError).with_info(e.to_string()),
+                                        ),
+                                    }
+                                });
+                            } else {
+                                self.monitor.send(
+                                    Event::new(EventType::ConnectionDenied)
+                                        .with_peer_result(sock.peer_addr()),
+                                );
                             }
-                        });
-                    } else {
-                        self.monitor.send(
-                            Event::new(EventType::ConnectionDenied)
-                                .with_peer_result(sock.peer_addr()),
-                        );
+                        }
+                        Err(e) => self
+                            .monitor
+                            .send(Event::new(EventType::ConnectionError).with_info(e.to_string())),
                     }
                 }
-                Err(e) => self
-                    .monitor
-                    .send(Event::new(EventType::ConnectionError).with_info(e.to_string())),
             }
         }
     }
@@ -414,6 +443,12 @@ where
 
         self.tls_config = Some(config);
 
+        self
+    }
+
+    /// Registers a shutdown signal to gracefully shutdown the app, ending the run/run_tls loop.
+    pub fn with_shutdown(mut self, cancel_token: CancellationToken) -> Self {
+        self.shutdown = Some(cancel_token);
         self
     }
 


### PR DESCRIPTION
I don't do much rust async. I find it overly annoying for little benefit. One of the reasons I found this crate was it's one of the few that don't have page long dependency trees, super simple, and low-latency.

I pulled in https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html
which is part of the tokio project https://github.com/tokio-rs/tokio/tree/master/tokio-util
as I think this might be exactly what we're looking for. 