### PR TITLE
fixing memory leaks

### DIFF
--- a/examples/shutdown/src/main.rs
+++ b/examples/shutdown/src/main.rs
@@ -14,13 +14,16 @@ fn main() -> Result<(), Box<dyn Error>> {
         .with_stateless_route("/hello", |_| Response::new(StatusCode::OK, "Hello world!"));
 
     // Shutdown the main app after 5 seconds
-    spawn(move || {
+    let t = spawn(move || {
         sleep(Duration::from_secs(5));
         let _ = shutdown_app.send(());
     });
 
     // Returns after shutdown signal
     app.run("0.0.0.0:8080").unwrap();
+
+    // Wait for thread to fully finish. Unneeded but placed here for full memory tests.
+    t.join().unwrap();
 
     Ok(())
 }

--- a/humphrey/src/thread/pool.rs
+++ b/humphrey/src/thread/pool.rs
@@ -105,6 +105,9 @@ impl ThreadPool {
 
     /// Stops the thread pool.
     pub fn stop(&mut self) {
+        if let Some(tx) = &self.tx {
+            tx.send(Message::Shutdown).unwrap();
+        };
         self.tx = None;
         if let Some(rt) = self.recovery_thread.take() {
             if rt.0.is_some() {


### PR DESCRIPTION
This is still very much WIP. I wanted to get feedback before proceeding (I'm only testing against `examples/shutdown`, no other runs, apps, etc). At least one issue is browsers send the `keep-alive` header and now using a browser will cause a pretty long timeout before exiting.

Using `cargo build --release --manifest-path examples/shutdown/Cargo.toml && valgrind --leak-check=full -- examples/shutdown/target/release/shutdown` on Fedora 39 (x86_64) + rustc 1.75 here is what I'm seeing. Testing with `curl localhost:8080/hello`, no other header info.

# Master
## 0 curls
```
==1121279== LEAK SUMMARY:
==1121279==    definitely lost: 0 bytes in 0 blocks
==1121279==    indirectly lost: 0 bytes in 0 blocks
==1121279==      possibly lost: 9,504 bytes in 33 blocks
==1121279==    still reachable: 10,698 bytes in 195 blocks
==1121279==         suppressed: 0 bytes in 0 blocks
```
## 5 curls
```
==1123754== LEAK SUMMARY:
==1123754==    definitely lost: 0 bytes in 0 blocks
==1123754==    indirectly lost: 0 bytes in 0 blocks
==1123754==      possibly lost: 9,504 bytes in 33 blocks
==1123754==    still reachable: 11,550 bytes in 217 blocks
==1123754==         suppressed: 0 bytes in 0 blocks
```

# grinkers/memory branch (this PR as of writing this)
## 0 curls
```
==1124996== HEAP SUMMARY:
==1124996==     in use at exit: 0 bytes in 0 blocks
==1124996==   total heap usage: 417 allocs, 417 frees, 33,002 bytes allocated
==1124996==
==1124996== All heap blocks were freed -- no leaks are possible
```
## 5 curls
```
==1124830== HEAP SUMMARY:
==1124830==     in use at exit: 0 bytes in 0 blocks
==1124830==   total heap usage: 683 allocs, 683 frees, 89,415 bytes allocated
==1124830==
==1124830== All heap blocks were freed -- no leaks are possible
```

At least a partial reproduction can be also seen with a small application like
```rust
fn main() -> Result<(), Box<dyn Error>> {
    let monitor = MonitorConfig::default();
    let mut thread_pool = ThreadPool::new(2);
    thread_pool.register_monitor(monitor);
    thread_pool.start();
    thread_pool.stop();
    drop(thread_pool);
    sleep(Duration::from_secs(5));
    Ok(())
}
```