### PR TITLE
Fix `warning: skipping duplicate package` warnings.

### DIFF
--- a/examples/stateful-tokio/Cargo.toml
+++ b/examples/stateful-tokio/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "stateful"
+name = "stateful-tokio"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/static-content-tokio/Cargo.toml
+++ b/examples/static-content-tokio/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "static-content"
+name = "static-content-tokio"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/tls-tokio/Cargo.toml
+++ b/examples/tls-tokio/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tls"
+name = "tls-tokio"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
```
warning: skipping duplicate package `stateful` found at `/home/grinkers/.cargo/git/checkouts/humphrey-d050187157c091df/101cc62/examples/stateful`
warning: skipping duplicate package `static-content` found at `/home/grinkers/.cargo/git/checkouts/humphrey-d050187157c091df/101cc62/examples/static-content`
warning: skipping duplicate package `tls` found at `/home/grinkers/.cargo/git/checkouts/humphrey-d050187157c091df/101cc62/examples/tls`
```
when using 
```toml
[dependencies]
humphrey = { git = "https://github.com/w-henderson/Humphrey.git" }
```

This ends up being spammed on every cargo test/check/build/run/etc on rustc 1.75.0.